### PR TITLE
feat(server): criar endpoint de busca de usuários

### DIFF
--- a/internal/repository/usuario_store.go
+++ b/internal/repository/usuario_store.go
@@ -19,6 +19,7 @@ type UserStore interface {
 	Create(ctx context.Context, usuario *model.Usuario) error
 	Update(ctx context.Context, usuario *model.Usuario) error
 	Delete(ctx context.Context, id string) (*model.Usuario, error)
+	Search(ctx context.Context, term string, limit int) ([]model.Usuario, error)
 }
 
 type usuarioStore struct {
@@ -133,4 +134,40 @@ func (s *usuarioStore) Delete(ctx context.Context, id_usuario string) (*model.Us
 	}
 
 	return usuario, nil
+}
+
+// Search busca usuários por user_id ou nome de exibição de forma case-insensitive.
+
+// NOTA: A spec Matrix exige que a busca considere apenas usuários "visíveis"
+// para o solicitante, ou seja: usuários que compartilham uma sala com ele,
+// usuários em salas públicas, ou em salas com histórico world_readable.
+// Esta implementação ainda não aplica esse filtro de visibilidade — ela
+// retorna todos os usuários locais que correspondem ao termo de busca.
+// TODO: adicionar joins com as tabelas de salas (canal) e membros para respeitar
+// a visibilidade conforme a spec.
+func (s *usuarioStore) Search(ctx context.Context, term string, limit int) ([]model.Usuario, error) {
+    query := `
+        SELECT id_usuario, nome_usuario, localpart_usuario, foto_usuario
+        FROM usuario
+        WHERE LOWER(id_usuario) LIKE LOWER($1)
+           OR LOWER(nome_usuario) LIKE LOWER($1)
+        LIMIT $2`
+
+    pattern := "%" + term + "%"
+    rows, err := s.db.QueryContext(ctx, query, pattern, limit)
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    usuarios := make([]model.Usuario, 0)
+    for rows.Next() {
+        var u model.Usuario
+        err = rows.Scan(&u.ID, &u.Nome, &u.LocalPart, &u.Foto)
+        if err != nil {
+            return nil, err
+        }
+        usuarios = append(usuarios, u)
+    }
+    return usuarios, nil
 }

--- a/internal/services/client/auth/routes_test.go
+++ b/internal/services/client/auth/routes_test.go
@@ -102,6 +102,10 @@ func (m *MockDeviceStore) Delete(ctx context.Context, id string) (*model.Disposi
 	return nil, nil
 }
 
+func (m *MockUserStore) Search(ctx context.Context, term string, limit int) ([]model.Usuario, error) {
+	return []model.Usuario{}, nil
+}
+
 // Helper function to create a valid JWT token for testing
 func createTestToken(userID, deviceID string) (string, error) {
 	originalKey := types.JWTSecretKey

--- a/internal/services/client/routes.go
+++ b/internal/services/client/routes.go
@@ -3,6 +3,7 @@ package client
 import (
 	"net/http"
 	"os"
+	"log"
 
 	"github.com/caio-bernardo/dragonite/internal/repository"
 	"github.com/caio-bernardo/dragonite/internal/services/client/auth"
@@ -41,6 +42,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux, authMiddleware types.Middle
 	// troca de eventos
 	mux.HandleFunc("PUT /_matrix/client/v3/rooms/{roomId}/send/{eventType}/{txnId}", util.UnimplementedHandler)
 	mux.HandleFunc("PUT /_matrix/client/v3/rooms/{roomId}/state/{eventType}/{stateKey}", util.UnimplementedHandler)
+
+	// busca de usuários
+	mux.Handle("POST /_matrix/client/v3/user_directory/search", authMiddleware(http.HandlerFunc(h.searchUsers)))
 }
 
 func (h *Handler) getVersions(w http.ResponseWriter, r *http.Request) {
@@ -48,4 +52,56 @@ func (h *Handler) getVersions(w http.ResponseWriter, r *http.Request) {
 		Versions: []string{"r0.0.5", "v1.18"},
 	}
 	util.WriteJSON(w, 200, response)
+}
+
+// searchUsers realiza a busca de usuários no diretório.
+// POST /_matrix/client/v3/user_directory/search
+// Ref: https://spec.matrix.org/v1.18/client-server-api/#post_matrixclientv3user_directorysearch
+func (h *Handler) searchUsers(w http.ResponseWriter, r *http.Request) {
+	var req UserSearchRequest
+	if err := util.ParseBody(r, &req); err != nil {
+		if err == types.ErrBodyRequired {
+			util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_NOT_JSON, "No request body"))
+		} else {
+			util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_BAD_JSON, "Invalid request body"))
+		}
+		return
+	}
+
+	if req.SearchTerm == "" {
+		util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_BAD_JSON, "search_term is required"))
+		return
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = 10 // padrão definido pela spec
+	}
+
+	// Busca limit+1 para detectar se há mais resultados do que o limite solicitado
+	usuarios, err := h.userStore.Search(r.Context(), req.SearchTerm, limit+1)
+	if err != nil {
+		log.Printf("[ERROR] POST /user_directory/search: %v", err)
+		util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, "Search failed"))
+		return
+	}
+
+	limited := len(usuarios) > limit
+	if limited {
+		usuarios = usuarios[:limit]
+	}
+
+	results := make([]UserSearchResult, len(usuarios))
+	for i, u := range usuarios {
+		results[i] = UserSearchResult{
+			UserID:      u.ID,
+			DisplayName: u.Nome,
+			AvatarURL:   u.Foto,
+		}
+	}
+
+	util.WriteJSON(w, http.StatusOK, UserSearchResponse{
+		Limited: limited,
+		Results: results,
+	})
 }

--- a/internal/services/client/routes_test.go
+++ b/internal/services/client/routes_test.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json" 
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +14,9 @@ import (
 )
 
 // MockUserStore is a mock implementation of repository.UserStore for testing
-type MockUserStore struct{}
+type MockUserStore struct{
+	SearchResults []model.Usuario
+}
 
 func (m *MockUserStore) GetAll(ctx context.Context, filter util.Filter) ([]model.Usuario, error) {
 	return []model.Usuario{}, nil
@@ -36,6 +40,10 @@ func (m *MockUserStore) Update(ctx context.Context, usuario *model.Usuario) erro
 
 func (m *MockUserStore) Delete(ctx context.Context, id string) (*model.Usuario, error) {
 	return nil, nil
+}
+
+func (m *MockUserStore) Search(ctx context.Context, term string, limit int) ([]model.Usuario, error) {
+	return m.SearchResults, nil
 }
 
 // MockDeviceStore is a mock implementation of repository.DeviceStore for testing
@@ -70,12 +78,85 @@ func (m *MockDeviceStore) Delete(ctx context.Context, id string) (*model.Disposi
 	return nil, nil
 }
 
+// Implementa repository.ChannelStore com 7 métodos conforme canal_store.go
+
+type MockChannelStore struct{}
+
+func (m *MockChannelStore) GetAll(ctx context.Context, filter util.Filter) ([]model.Canal, error) {
+	return []model.Canal{}, nil
+}
+
+func (m *MockChannelStore) GetByID(ctx context.Context, id string) (*model.Canal, error) {
+	return nil, nil
+}
+
+func (m *MockChannelStore) Create(ctx context.Context, props *model.Canal) error {
+	return nil
+}
+
+func (m *MockChannelStore) Update(ctx context.Context, props *model.Canal) error {
+	return nil
+}
+
+func (m *MockChannelStore) Delete(ctx context.Context, id_canal string) (*model.Canal, error) {
+	return nil, nil
+}
+
+func (m *MockChannelStore) ListPublic(ctx context.Context, limit int, sinceToken string) ([]model.Canal, string, error) {
+	return []model.Canal{}, "", nil
+}
+
+func (m *MockChannelStore) UpdateMemberCount(ctx context.Context, canalID string, delta int) error {
+	return nil
+}
+
+// Implementa repository.UsuarioCanalStore com 8 métodos conforme usuario_canal_store.go
+
+type MockUsuarioCanalStore struct{}
+
+func (m *MockUsuarioCanalStore) GetAll(ctx context.Context, filter util.Filter) ([]model.UsuarioCanal, error) {
+	return []model.UsuarioCanal{}, nil
+}
+
+func (m *MockUsuarioCanalStore) GetByComposedID(ctx context.Context, id_usuario string, id_canal string) (*model.UsuarioCanal, error) {
+	return nil, nil
+}
+
+func (m *MockUsuarioCanalStore) GetAllByUsuarioID(ctx context.Context, id_usuario string) ([]model.UsuarioCanal, error) {
+	return []model.UsuarioCanal{}, nil
+}
+
+func (m *MockUsuarioCanalStore) GetAllByCanalID(ctx context.Context, id_canal string) ([]model.UsuarioCanal, error) {
+	return []model.UsuarioCanal{}, nil
+}
+
+func (m *MockUsuarioCanalStore) Create(ctx context.Context, props *model.UsuarioCanal) error {
+	return nil
+}
+
+func (m *MockUsuarioCanalStore) Update(ctx context.Context, props *model.UsuarioCanal) error {
+	return nil
+}
+
+func (m *MockUsuarioCanalStore) Delete(ctx context.Context, id_usuario string, id_canal string) (*model.UsuarioCanal, error) {
+	return nil, nil
+}
+
+func (m *MockUsuarioCanalStore) AddOrUpdateMembership(ctx context.Context, mem *model.UsuarioCanal) error {
+	return nil
+}
+
+// newTestHandler centraliza a criação do Handler com mocks, evitando
+// repetição em cada teste e garantindo que todos usem os mesmos 4 argumentos
+func newTestHandler(userStore *MockUserStore) *Handler {
+	return NewHandler(userStore, &MockDeviceStore{}, &MockChannelStore{}, &MockUsuarioCanalStore{})
+}
+
 func TestGetVersionsHandler(t *testing.T) {
-	userStore := &MockUserStore{}
-	deviceStore := &MockDeviceStore{}
-	h := NewHandler(userStore, deviceStore)
+	h := newTestHandler(&MockUserStore{})
 	server := httptest.NewServer(http.HandlerFunc(h.getVersions))
 	defer server.Close()
+
 	resp, err := http.Get(server.URL)
 	if err != nil {
 		t.Fatalf("error making request to server. Err: %v", err)
@@ -93,4 +174,94 @@ func TestGetVersionsHandler(t *testing.T) {
 	if expected != string(body) {
 		t.Errorf("expected response body to be %v; got %v", expected, string(body))
 	}
+}
+
+func TestSearchUsersHandler(t *testing.T) {
+	// subtestes cobrem os três cenários relevantes da spec:
+	// resultado normal, truncamento por limite, e campo obrigatório ausente
+
+	t.Run("retorna resultados válidos", func(t *testing.T) {
+		userStore := &MockUserStore{
+			SearchResults: []model.Usuario{
+				{ID: "@alice:example.com", Nome: "Alice", Foto: "mxc://example.com/alice"},
+			},
+		}
+		h := newTestHandler(userStore)
+		server := httptest.NewServer(http.HandlerFunc(h.searchUsers))
+		defer server.Close()
+
+		body := `{"search_term": "alice", "limit": 10}`
+		resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("error making request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200; got %v", resp.Status)
+		}
+		var result UserSearchResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("error decoding response: %v", err)
+		}
+		if result.Limited {
+			t.Error("expected limited=false")
+		}
+		if len(result.Results) != 1 {
+			t.Fatalf("expected 1 result; got %d", len(result.Results))
+		}
+		if result.Results[0].UserID != "@alice:example.com" {
+			t.Errorf("expected user_id @alice:example.com; got %v", result.Results[0].UserID)
+		}
+	})
+
+	t.Run("limited=true quando resultados excedem o limite", func(t *testing.T) {
+		// o mock retorna 2 usuários; o handler pede limit+1=2, então
+		// len(usuarios) > limit → limited=true e o segundo é cortado
+		userStore := &MockUserStore{
+			SearchResults: []model.Usuario{
+				{ID: "@a:example.com", Nome: "A"},
+				{ID: "@b:example.com", Nome: "B"},
+			},
+		}
+		h := newTestHandler(userStore)
+		server := httptest.NewServer(http.HandlerFunc(h.searchUsers))
+		defer server.Close()
+
+		body := `{"search_term": "a", "limit": 1}`
+		resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("error making request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var result UserSearchResponse
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("error decoding response: %v", err)
+		}
+		if !result.Limited {
+			t.Error("expected limited=true")
+		}
+		if len(result.Results) != 1 {
+			t.Errorf("expected 1 result after truncation; got %d", len(result.Results))
+		}
+	})
+
+	t.Run("search_term vazio retorna 400", func(t *testing.T) {
+		// search_term é obrigatório pela spec, então a ausência deve retornar Bad Request
+		h := newTestHandler(&MockUserStore{})
+		server := httptest.NewServer(http.HandlerFunc(h.searchUsers))
+		defer server.Close()
+
+		body := `{"search_term": ""}`
+		resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString(body))
+		if err != nil {
+			t.Fatalf("error making request: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("expected 400; got %v", resp.Status)
+		}
+	})
 }

--- a/internal/services/client/schemas.go
+++ b/internal/services/client/schemas.go
@@ -4,3 +4,22 @@ type SupportedVersionsResponse struct {
 	Versions         []string        `json:"versions"`
 	UnstableFeatures map[string]bool `json:"unstable_features,omitempty"`
 }
+
+// Corpo da requisição POST /_matrix/client/v3/user_directory/search
+type UserSearchRequest struct {
+	SearchTerm string `json:"search_term"`         // obrigatório pela spec
+	Limit      int    `json:"limit"`
+}
+
+// Um usuário retornado na busca
+type UserSearchResult struct {
+	UserID      string `json:"user_id"`            // obrigatório
+	DisplayName string `json:"display_name,omitempty"`
+	AvatarURL   string `json:"avatar_url,omitempty"`
+}
+
+// Resposta ao POST /_matrix/client/v3/user_directory/search
+type UserSearchResponse struct {
+	Limited bool               `json:"limited"`    // obrigatório, true se resultados foram truncados pelo limite
+	Results []UserSearchResult `json:"results"`    // obrigatório
+}


### PR DESCRIPTION
**OBS:** Precisei fazer umas maracutaias com comandos git e acabou aparecendo que modifiquei cada um desses arquivos inteiramente (ou talvez seja problema de CRLF/LF novamente), porém só adicionei algumas partes que podem ser acompanhadas com o resumo abaixo.

Resumos das alterações:

- `usuario_store.go` — Adicionado o método Search à interface UserStore, realiza busca case-insensitive em id_usuario e nome_usuario. **Nota**: a spec exige filtro de visibilidade por sala, a implementação atual retorna todos os usuários locais; o filtro completo está documentado com TODO.

- `schemas.go` — Adicionados os tipos UserSearchRequest, UserSearchResult e UserSearchResponse seguindo os campos definidos pela spec.

- `routes.go` — Rota registrada com auth middleware, o handler valida o search_term obrigatório, define o limit padrão como 10 e marca limited: true quando os resultados são truncados.

- `routes_test.go` — Adicionados mocks (MockChannelStore e MockUsuarioCanalStore) que faltavam, corrigida a call signature de NewHandler e adicionado o TestSearchUsersHandler cobrindo resultado válido, limited=true ao exceder o limite, e search_term vazio.

- `auth/routes_test.go` — Adicionado Search ao MockUserStore local para satisfazer a interface atualizada.