### PR TITLE
feat(federation): adiciona rota de profile do usuário, servidores públicos e de federate join

### DIFF
--- a/frontend/src/lib/components/NavigationSideBarView.svelte
+++ b/frontend/src/lib/components/NavigationSideBarView.svelte
@@ -3,7 +3,7 @@
 	import { matrixService } from '$lib/stores/matrix.svelte';
 	import { ArrowLeftRightIcon, HouseIcon, MessageSquare, SettingsIcon } from '@lucide/svelte';
 	import { Avatar, Navigation } from '@skeletonlabs/skeleton-svelte';
-  import UserSearchBar from '$lib/components/UserSearchBar.svelte';
+    import UserSearchBar from '$lib/components/UserSearchBar.svelte';
 
 	let isLayoutRail = $state(true);
 

--- a/frontend/src/routes/dashboard/rooms/[id]/+page.svelte
+++ b/frontend/src/routes/dashboard/rooms/[id]/+page.svelte
@@ -16,7 +16,11 @@
         matrixService.syncState === 'CATCHUP'
     );
 
-    let messages = $state(matrixService.getRoomMessages(roomId));
+    let messageVersion = $state(0);
+    let messages = $derived.by(() => {
+        messageVersion;
+        return matrixService.getRoomMessages(roomId);
+    });
     let roomName = $derived(matrixService.getRoomName(roomId));
 
     let currentMessage = $state('');
@@ -69,7 +73,7 @@
         scrollToBottom('instant');
 
         unsubscribe = matrixService.onRoomTimeline(roomId, () => {
-            messages = matrixService.getRoomMessages(roomId);
+            messageVersion++;
             setTimeout(() => scrollToBottom('smooth'), 0);
         });
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"allowArbitraryExtensions": true,
 		"rewriteRelativeImportExtensions": true,
 		"allowJs": true,
 		"checkJs": true,

--- a/internal/repository/canal_store.go
+++ b/internal/repository/canal_store.go
@@ -4,11 +4,20 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-
+	"strings"
+	
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
 )
+
+// ListPublicParams encapsula todos os parâmetros de busca de canais públicos
+type ListPublicParams struct {
+    Limit      int       // 0 = sem limite
+    SinceToken string    // token opaco de paginação (encoda offset)
+    SearchTerm string    // vazio = sem filtro de texto
+    RoomTypes  []*string // nil = sem filtro; nil dentro do slice = salas sem tipo
+}
 
 type ChannelStore interface {
 	GetAll(ctx context.Context, filter util.Filter) ([]model.Canal, error)
@@ -17,7 +26,7 @@ type ChannelStore interface {
 	Update(ctx context.Context, props *model.Canal) error
 	Delete(ctx context.Context, id_canal string) (*model.Canal, error)
 	// Adicionados para suporte às rotas Matrix de rooms
-	ListPublic(ctx context.Context, limit int, sinceToken string) ([]model.Canal, string, error)
+	ListPublic(ctx context.Context, params ListPublicParams) (canais []model.Canal, nextBatch string, prevBatch string, total int, err error)
 	UpdateMemberCount(ctx context.Context, canalID string, delta int) error
 	UpsertEstadoAtual(ctx context.Context, estado *model.EstadoAtualCanal) error
 }
@@ -143,38 +152,96 @@ func (s *canalStore) Delete(ctx context.Context, id_canal string) (*model.Canal,
 	return canal, nil
 }
 
-func (s *canalStore) ListPublic(ctx context.Context, limit int, sinceToken string) ([]model.Canal, string, error) {
-	offset := 0
-	if sinceToken != "" {
-		fmt.Sscanf(sinceToken, "%d", &offset)
-	}
+func (s *canalStore) ListPublic(ctx context.Context, params ListPublicParams) ([]model.Canal, string, string, int, error) {
+    offset := 0
+    if params.SinceToken != "" {
+        fmt.Sscanf(params.SinceToken, "%d", &offset)
+    }
 
-	query := "SELECT" + canalColumns + `
-		FROM canal
-		WHERE is_public_canal = true
-		ORDER BY member_count DESC
-		LIMIT $1 OFFSET $2`
+    // Constrói WHERE dinamicamente
+    conditions := []string{"is_public_canal = true"}
+    args := []any{}
 
-	rows, err := s.db.QueryContext(ctx, query, limit, offset)
-	if err != nil {
-		return nil, "", err
-	}
-	defer rows.Close()
+    if params.SearchTerm != "" {
+        n := len(args) + 1
+        conditions = append(conditions, fmt.Sprintf(
+            "(nome_canal ILIKE $%d OR descricao_canal ILIKE $%d OR canonical_alias ILIKE $%d)",
+            n, n, n,
+        ))
+        args = append(args, "%"+params.SearchTerm+"%")
+    }
 
-	canais := make([]model.Canal, 0)
-	for rows.Next() {
-		var c model.Canal
-		if err := scanCanal(rows, &c); err != nil {
-			return nil, "", err
-		}
-		canais = append(canais, c)
-	}
+    if params.RoomTypes != nil {
+        var typeConds []string
+        for _, rt := range params.RoomTypes {
+            if rt == nil {
+                typeConds = append(typeConds, "room_type IS NULL")
+            } else {
+                n := len(args) + 1
+                typeConds = append(typeConds, fmt.Sprintf("room_type = $%d", n))
+                args = append(args, *rt)
+            }
+        }
+        if len(typeConds) > 0 {
+            conditions = append(conditions, "("+strings.Join(typeConds, " OR ")+")")
+        }
+    }
 
-	nextBatch := ""
-	if len(canais) == limit {
-		nextBatch = fmt.Sprintf("%d", offset+limit)
-	}
-	return canais, nextBatch, rows.Err()
+    where := "WHERE " + strings.Join(conditions, " AND ")
+
+    // Contagem total
+    var total int
+    if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM canal "+where, args...).Scan(&total); err != nil {
+        return nil, "", "", 0, err
+    }
+
+    // Query de dados com paginação
+    dataArgs := make([]any, len(args))
+    copy(dataArgs, args)
+
+    var limitClause string
+    if params.Limit > 0 {
+        dataArgs = append(dataArgs, params.Limit, offset)
+        limitClause = fmt.Sprintf(" LIMIT $%d OFFSET $%d", len(dataArgs)-1, len(dataArgs))
+    } else {
+        dataArgs = append(dataArgs, offset)
+        limitClause = fmt.Sprintf(" OFFSET $%d", len(dataArgs))
+    }
+
+    dataQuery := "SELECT" + canalColumns + " FROM canal " + where +
+        " ORDER BY member_count DESC" + limitClause
+
+    rows, err := s.db.QueryContext(ctx, dataQuery, dataArgs...)
+    if err != nil {
+        return nil, "", "", 0, err
+    }
+    defer rows.Close()
+
+    canais := make([]model.Canal, 0)
+    for rows.Next() {
+        var c model.Canal
+        if err := scanCanal(rows, &c); err != nil {
+            return nil, "", "", 0, err
+        }
+        canais = append(canais, c)
+    }
+    if err := rows.Err(); err != nil {
+        return nil, "", "", 0, err
+    }
+
+    // Tokens de paginação
+    nextBatch := ""
+    if params.Limit > 0 && len(canais) == params.Limit {
+        nextBatch = fmt.Sprintf("%d", offset+params.Limit)
+    }
+    prevBatch := ""
+    if offset > 0 && params.Limit > 0 {
+        if prev := offset - params.Limit; prev >= 0 {
+            prevBatch = fmt.Sprintf("%d", prev)
+        }
+    }
+
+    return canais, nextBatch, prevBatch, total, nil
 }
 
 func (s *canalStore) UpdateMemberCount(ctx context.Context, canalID string, delta int) error {

--- a/internal/repository/canal_store_test.go
+++ b/internal/repository/canal_store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"fmt"
 	
 
 	"github.com/caio-bernardo/dragonite/internal/model"
@@ -111,6 +112,116 @@ func TestCanalStoreCRUDAndCleanup(t *testing.T) {
 	}
 }
 
+func TestCanalStore_ListPublic_Pagination(t *testing.T) {
+	resetTables(t)
+
+	owner := model.Usuario{
+		ID: "@page-owner:example.com", LocalPart: "page-owner",
+		Nome: "Owner", Senha: "password", DataCriacao: baseTime,
+	}
+	insertUsuario(t, owner)
+
+	store := NewChannelStore(testDB)
+	ctx := context.Background()
+
+	for i := 1; i <= 3; i++ {
+		c := model.Canal{
+			ID:                fmt.Sprintf("!page-room%d:example.com", i),
+			LocalPart:         fmt.Sprintf("page-room%d", i),
+			ServerName:        "example.com",
+			Nome:              fmt.Sprintf("Page Room %d", i),
+			IsPublic:          true,
+			JoinRules:         "public",
+			GuestAccess:       "forbidden",
+			HistoryVisibility: "shared",
+			Versao:            "11",
+			CriadorID:         owner.ID,
+			MemberCount:       i,
+			DataCriacao:       baseTime,
+		}
+		if err := store.Create(ctx, &c); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+	}
+
+	// Primeira página: limit=2
+	page1, nextBatch, prevBatch, total, err := store.ListPublic(ctx, ListPublicParams{Limit: 2})
+	if err != nil {
+		t.Fatalf("ListPublic() page 1 failed: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("expected 2 canais na página 1, got %d", len(page1))
+	}
+	if nextBatch == "" {
+		t.Fatal("expected nextBatch na página 1")
+	}
+	if prevBatch != "" {
+		t.Fatalf("expected empty prevBatch na página 1, got %q", prevBatch)
+	}
+	if total != 3 {
+		t.Fatalf("expected total 3, got %d", total)
+	}
+
+	// Segunda página usando o token retornado
+	page2, nextBatch2, prevBatch2, _, err := store.ListPublic(ctx, ListPublicParams{Limit: 2, SinceToken: nextBatch})
+	if err != nil {
+		t.Fatalf("ListPublic() page 2 failed: %v", err)
+	}
+	if len(page2) != 1 {
+		t.Fatalf("expected 1 canal na página 2, got %d", len(page2))
+	}
+	if nextBatch2 != "" {
+		t.Fatalf("expected empty nextBatch na página 2, got %q", nextBatch2)
+	}
+	if prevBatch2 == "" {
+		t.Fatal("expected prevBatch na página 2")
+	}
+}
+
+func TestCanalStore_ListPublic_SearchTerm(t *testing.T) {
+	resetTables(t)
+
+	owner := model.Usuario{
+		ID: "@search-owner:example.com", LocalPart: "search-owner",
+		Nome: "Owner", Senha: "password", DataCriacao: baseTime,
+	}
+	insertUsuario(t, owner)
+
+	store := NewChannelStore(testDB)
+	ctx := context.Background()
+
+	cheese := model.Canal{
+		ID: "!cheese:example.com", LocalPart: "cheese", ServerName: "example.com",
+		Nome: "Cheese Lovers", Descricao: "All about cheese", IsPublic: true,
+		JoinRules: "public", GuestAccess: "forbidden", HistoryVisibility: "shared",
+		Versao: "11", CriadorID: owner.ID, MemberCount: 10, DataCriacao: baseTime,
+	}
+	other := model.Canal{
+		ID: "!other:example.com", LocalPart: "other", ServerName: "example.com",
+		Nome: "Unrelated Room", Descricao: "Nothing here", IsPublic: true,
+		JoinRules: "public", GuestAccess: "forbidden", HistoryVisibility: "shared",
+		Versao: "11", CriadorID: owner.ID, MemberCount: 2, DataCriacao: baseTime,
+	}
+	for _, c := range []model.Canal{cheese, other} {
+		if err := store.Create(ctx, &c); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+	}
+
+	canais, _, _, total, err := store.ListPublic(ctx, ListPublicParams{SearchTerm: "cheese"})
+	if err != nil {
+		t.Fatalf("ListPublic() with search failed: %v", err)
+	}
+	if len(canais) != 1 {
+		t.Fatalf("expected 1 canal, got %d", len(canais))
+	}
+	if canais[0].ID != cheese.ID {
+		t.Fatalf("expected cheese room, got %s", canais[0].ID)
+	}
+	if total != 1 {
+		t.Fatalf("expected total 1, got %d", total)
+	}
+}
 
 func TestCanalStore_ListPublic(t *testing.T) {
 	resetTables(t)
@@ -143,7 +254,7 @@ func TestCanalStore_ListPublic(t *testing.T) {
 		}
 	}
 
-	canais, nextBatch, err := store.ListPublic(ctx, 10, "")
+	canais, nextBatch, prevBatch, total, err := store.ListPublic(ctx, ListPublicParams{Limit: 10})
 	if err != nil {
 		t.Fatalf("ListPublic() failed: %v", err)
 	}
@@ -156,6 +267,12 @@ func TestCanalStore_ListPublic(t *testing.T) {
 	}
 	if nextBatch != "" {
 		t.Fatalf("expected empty nextBatch, got %q", nextBatch)
+	}
+	if prevBatch != "" {
+		t.Fatalf("expected empty prevBatch, got %q", prevBatch)
+	}
+	if total != 2 {
+		t.Fatalf("expected total 2, got %d", total)
 	}
 }
 

--- a/internal/repository/evento_store.go
+++ b/internal/repository/evento_store.go
@@ -21,6 +21,7 @@ type EventoStore interface {
 	CheckNew(ctx context.Context, userID string, since model.SyncToken) (bool, error)
 	GetSince(ctx context.Context, userID string, since model.SyncToken) ([]model.Evento, model.SyncToken, error)
 	GetMaxGlobalStreamOrdering(ctx context.Context) (int64, error)
+	GetCurrentStateEvents(ctx context.Context, roomID string) ([]model.Evento, error)
 }
 
 type eventoStore struct {
@@ -256,4 +257,31 @@ func (s *eventoStore) getCanaisIDByUserID(ctx context.Context, userID string) ([
 	}
 
 	return canais, nil
+}
+
+func (s *eventoStore) GetCurrentStateEvents(ctx context.Context, roomID string) ([]model.Evento, error) {
+    query := `
+        SELECT e.id_evento, e.tipo_evento, e.fk_id_canal, e.fk_id_sender,
+               e.state_key, e.conteudo_evento::text, e.origem_servidor_evento_ts,
+               e.stream_ordering_evento, e.txn_id
+        FROM estado_atual_canal eac
+        JOIN evento e ON e.id_evento = eac.fk_id_evento
+        WHERE eac.fk_id_canal = $1`
+
+    rows, err := s.db.QueryContext(ctx, query, roomID)
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
+
+    eventos := make([]model.Evento, 0)
+    for rows.Next() {
+        var e model.Evento
+        if err := rows.Scan(&e.ID, &e.Tipo, &e.CanalID, &e.SenderID, &e.StateKey,
+            &e.Conteudo, &e.OrigemServidorTS, &e.StreamOrdering, &e.TxnID); err != nil {
+            return nil, err
+        }
+        eventos = append(eventos, e)
+    }
+    return eventos, rows.Err()
 }

--- a/internal/repository/evento_store_test.go
+++ b/internal/repository/evento_store_test.go
@@ -1161,3 +1161,76 @@ func TestGetCanaisIDByUserIDReturnsDistinctCanalIDs(t *testing.T) {
 		}
 	}
 }
+
+func TestEventoStore_GetCurrentStateEvents(t *testing.T) {
+	resetTables(t)
+	ctx := context.Background()
+
+	user := model.Usuario{
+		ID: "@state-user:example.com", LocalPart: "state-user",
+		Nome: "State User", Senha: "password", DataCriacao: baseTime,
+	}
+	insertUsuario(t, user)
+
+	canal := model.Canal{
+		ID: "!state-room:example.com", LocalPart: "state-room",
+		ServerName: "example.com", Nome: "State Room", IsPublic: true,
+		JoinRules: "public", GuestAccess: "forbidden", HistoryVisibility: "shared",
+		Versao: "11", CriadorID: user.ID, MemberCount: 1, DataCriacao: baseTime,
+	}
+	insertCanal(t, canal)
+
+	stateEventos := []model.Evento{
+		{
+			ID: "$create:example.com", Tipo: "m.room.create",
+			CanalID: canal.ID, SenderID: user.ID, StateKey: "",
+			Conteudo: `{"creator":"@state-user:example.com"}`, 
+			OrigemServidorTS: 1000,  StreamOrdering:   9001,
+		},
+		{
+			ID: "$join-rules:example.com", Tipo: "m.room.join_rules",
+			CanalID: canal.ID, SenderID: user.ID, StateKey: "",
+			Conteudo: `{"join_rule":"public"}`, OrigemServidorTS: 1001, StreamOrdering: 9002,
+		},
+		{
+			ID: "$member:example.com", Tipo: "m.room.member",
+			CanalID: canal.ID, SenderID: user.ID, StateKey: user.ID,
+			Conteudo: `{"membership":"join"}`, OrigemServidorTS: 1002, StreamOrdering: 9003,
+		},
+	}
+	for _, e := range stateEventos {
+		insertEvento(t, e)
+	}
+	insertEstadoAtualCanal(t, canal.ID, "m.room.create", "", stateEventos[0].ID)
+	insertEstadoAtualCanal(t, canal.ID, "m.room.join_rules", "", stateEventos[1].ID)
+	insertEstadoAtualCanal(t, canal.ID, "m.room.member", user.ID, stateEventos[2].ID)
+
+	store := NewEventoStore(testDB)
+
+	got, err := store.GetCurrentStateEvents(ctx, canal.ID)
+	if err != nil {
+		t.Fatalf("GetCurrentStateEvents() failed: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 state events, got %d", len(got))
+	}
+
+	gotIDs := make(map[string]bool)
+	for _, e := range got {
+		gotIDs[e.ID] = true
+	}
+	for _, e := range stateEventos {
+		if !gotIDs[e.ID] {
+			t.Errorf("expected event %s in result", e.ID)
+		}
+	}
+
+	// Sala desconhecida deve retornar lista vazia
+	got2, err := store.GetCurrentStateEvents(ctx, "!naoexiste:example.com")
+	if err != nil {
+		t.Fatalf("GetCurrentStateEvents() for unknown room failed: %v", err)
+	}
+	if len(got2) != 0 {
+		t.Fatalf("expected 0 events for unknown room, got %d", len(got2))
+	}
+}

--- a/internal/repository/usuario_store.go
+++ b/internal/repository/usuario_store.go
@@ -198,7 +198,7 @@ func (s *usuarioStore) GetNameAndPhotoByID(ctx context.Context, id string) (*mod
 // ClearProfileKey define uma coluna específica do perfil como nula no banco de dados.
 func (s *usuarioStore) ClearProfileKey(ctx context.Context, userID string, colunaDB string) error {
 
-	query := fmt.Sprintf(`UPDATE Usuario SET %s = NULL WHERE id_usuario = $1`, colunaDB)
+	query := fmt.Sprintf(`UPDATE Usuario SET %s = '' WHERE id_usuario = $1`, colunaDB)
 
 	resultado, err := s.db.ExecContext(ctx, query, userID)
 	if err != nil {

--- a/internal/repository/usuario_store.go
+++ b/internal/repository/usuario_store.go
@@ -183,7 +183,7 @@ func (s *usuarioStore) GetNameAndPhotoByID(ctx context.Context, id string) (*mod
 	row := s.db.QueryRowContext(ctx, query, id)
 
 	var d model.Usuario
-	err := row.Scan(&d.ID, &d.Nome, &d.Foto)
+	err := row.Scan(&d.Nome, &d.Foto)
 
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/repository/usuario_store_test.go
+++ b/internal/repository/usuario_store_test.go
@@ -118,3 +118,233 @@ func TestUsuarioStoreCreate_LocalpartAlreadyExists(t *testing.T) {
 		t.Fatalf("expected ErrLocalpartInUse, got: %v", err)
 	}
 }
+
+func TestUsuarioStore_GetByID_NotFound(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+
+	_, err := store.GetByID(context.Background(), "@naoexiste:example.com")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_GetByLocal_NotFound(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+
+	_, err := store.GetByLocal(context.Background(), "naoexiste")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_Update_NotFound(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+
+	err := store.Update(context.Background(), &model.Usuario{
+		ID:          "@naoexiste:example.com",
+		LocalPart:   "naoexiste",
+		Nome:        "Ghost",
+		DataCriacao: baseTime,
+	})
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_Delete_NotFound(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+
+	_, err := store.Delete(context.Background(), "@naoexiste:example.com")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_Search(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+	ctx := context.Background()
+
+	users := []model.Usuario{
+		{ID: "@alice:example.com", LocalPart: "alice", Nome: "Alice Wonder", Senha: "s", DataCriacao: baseTime},
+		{ID: "@bob:example.com", LocalPart: "bob", Nome: "Bob Builder", Senha: "s", DataCriacao: baseTime},
+		{ID: "@charlie:example.com", LocalPart: "charlie", Nome: "Charlie Chaplin", Senha: "s", DataCriacao: baseTime},
+	}
+	for _, u := range users {
+		u := u
+		if err := store.Create(ctx, &u); err != nil {
+			t.Fatalf("Create() failed: %v", err)
+		}
+	}
+
+	// Busca por nome parcial
+	results, err := store.Search(ctx, "alice", 10)
+	if err != nil {
+		t.Fatalf("Search() failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].ID != "@alice:example.com" {
+		t.Errorf("expected alice, got %s", results[0].ID)
+	}
+
+	// Busca por localpart via user_id
+	results, err = store.Search(ctx, "bob", 10)
+	if err != nil {
+		t.Fatalf("Search() failed: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// Busca sem resultado
+	results, err = store.Search(ctx, "xyz_naoexiste", 10)
+	if err != nil {
+		t.Fatalf("Search() failed: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+
+	// Respeita limit
+	results, err = store.Search(ctx, "example", 2)
+	if err != nil {
+		t.Fatalf("Search() failed: %v", err)
+	}
+	if len(results) > 2 {
+		t.Fatalf("expected at most 2 results, got %d", len(results))
+	}
+}
+
+func TestUsuarioStore_GetNameAndPhotoByID(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+	ctx := context.Background()
+
+	user := model.Usuario{
+		ID:          "@alice:example.com",
+		LocalPart:   "alice",
+		Nome:        "Alice",
+		Senha:       "secret",
+		Foto:        "https://example.com/alice.png",
+		DataCriacao: baseTime,
+	}
+	if err := store.Create(ctx, &user); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	got, err := store.GetNameAndPhotoByID(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetNameAndPhotoByID() failed: %v", err)
+	}
+	if got.Nome != user.Nome {
+		t.Errorf("expected nome %q, got %q", user.Nome, got.Nome)
+	}
+	if got.Foto != user.Foto {
+		t.Errorf("expected foto %q, got %q", user.Foto, got.Foto)
+	}
+
+	// Usuário sem foto
+	userSemFoto := model.Usuario{
+		ID:          "@bob:example.com",
+		LocalPart:   "bob",
+		Nome:        "Bob",
+		Senha:       "secret",
+		DataCriacao: baseTime,
+	}
+	if err := store.Create(ctx, &userSemFoto); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+	got, err = store.GetNameAndPhotoByID(ctx, userSemFoto.ID)
+	if err != nil {
+		t.Fatalf("GetNameAndPhotoByID() sem foto failed: %v", err)
+	}
+	if got.Foto != "" {
+		t.Errorf("expected empty foto, got %q", got.Foto)
+	}
+
+	// Não encontrado
+	_, err = store.GetNameAndPhotoByID(ctx, "@naoexiste:example.com")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_UpdateProfileKey(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+	ctx := context.Background()
+
+	user := model.Usuario{
+		ID:          "@alice:example.com",
+		LocalPart:   "alice",
+		Nome:        "Alice",
+		Senha:       "secret",
+		DataCriacao: baseTime,
+	}
+	if err := store.Create(ctx, &user); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Atualiza nome
+	if err := store.UpdateProfileKey(ctx, user.ID, "nome_usuario", "Alice Nova"); err != nil {
+		t.Fatalf("UpdateProfileKey() failed: %v", err)
+	}
+	got, _ := store.GetByID(ctx, user.ID)
+	if got.Nome != "Alice Nova" {
+		t.Errorf("expected nome 'Alice Nova', got %q", got.Nome)
+	}
+
+	// Atualiza foto
+	if err := store.UpdateProfileKey(ctx, user.ID, "foto_usuario", "https://example.com/new.png"); err != nil {
+		t.Fatalf("UpdateProfileKey() foto failed: %v", err)
+	}
+	got, _ = store.GetByID(ctx, user.ID)
+	if got.Foto != "https://example.com/new.png" {
+		t.Errorf("expected foto atualizada, got %q", got.Foto)
+	}
+
+	// Usuário não encontrado
+	err := store.UpdateProfileKey(ctx, "@naoexiste:example.com", "nome_usuario", "Ghost")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUsuarioStore_ClearProfileKey(t *testing.T) {
+	resetTables(t)
+	store := NewUsuarioStore(testDB)
+	ctx := context.Background()
+
+	user := model.Usuario{
+		ID:          "@alice:example.com",
+		LocalPart:   "alice",
+		Nome:        "Alice",
+		Senha:       "secret",
+		Foto:        "https://example.com/alice.png",
+		DataCriacao: baseTime,
+	}
+	if err := store.Create(ctx, &user); err != nil {
+		t.Fatalf("Create() failed: %v", err)
+	}
+
+	// Limpa foto
+	if err := store.ClearProfileKey(ctx, user.ID, "foto_usuario"); err != nil {
+		t.Fatalf("ClearProfileKey() failed: %v", err)
+	}
+	got, _ := store.GetByID(ctx, user.ID)
+	if got.Foto != "" {
+		t.Errorf("expected foto cleared, got %q", got.Foto)
+	}
+
+	// Usuário não encontrado
+	err := store.ClearProfileKey(ctx, "@naoexiste:example.com", "foto_usuario")
+	if !errors.Is(err, types.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,7 +27,7 @@ func (s *AppServer) RegisterRoutes() http.Handler {
 	mux := http.NewServeMux()
 
 	clientHandler := client.NewHandler(userStore, deviceStore, canalStore, usuarioCanalStore, eventoStore, notif)
-	federationHandler := federation.NewHandler(&s.Config, userStore)
+	federationHandler := federation.NewHandler(&s.Config, userStore, canalStore)
 
 	// Registra rotas
 	mux.HandleFunc("GET /health", s.healthHandler)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,7 +27,7 @@ func (s *AppServer) RegisterRoutes() http.Handler {
 	mux := http.NewServeMux()
 
 	clientHandler := client.NewHandler(userStore, deviceStore, canalStore, usuarioCanalStore, eventoStore, notif)
-	federationHandler := federation.NewHandler(&s.Config)
+	federationHandler := federation.NewHandler(&s.Config, userStore)
 
 	// Registra rotas
 	mux.HandleFunc("GET /health", s.healthHandler)

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -27,7 +27,7 @@ func (s *AppServer) RegisterRoutes() http.Handler {
 	mux := http.NewServeMux()
 
 	clientHandler := client.NewHandler(userStore, deviceStore, canalStore, usuarioCanalStore, eventoStore, notif)
-	federationHandler := federation.NewHandler(&s.Config, userStore, canalStore)
+	federationHandler := federation.NewHandler(&s.Config, userStore, canalStore, eventoStore, usuarioCanalStore)
 
 	// Registra rotas
 	mux.HandleFunc("GET /health", s.healthHandler)

--- a/internal/services/client/rooms/routes.go
+++ b/internal/services/client/rooms/routes.go
@@ -66,9 +66,13 @@ func (h *Handler) getPublicRooms(w http.ResponseWriter, r *http.Request) {
 		}
 		limit = parsed
 	}
-	since := r.URL.Query().Get("since")
 
-	canais, nextBatch, err := h.canalStore.ListPublic(ctx, limit, since)
+	params := repository.ListPublicParams{
+		Limit:      limit,
+		SinceToken: r.URL.Query().Get("since"),
+	}
+
+	canais, nextBatch, _, total, err := h.canalStore.ListPublic(ctx, params)
 	if err != nil {
 		log.Printf("[ERROR] GET /publicRooms: %v", err)
 		util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, "Failed to list rooms"))
@@ -97,13 +101,12 @@ func (h *Handler) getPublicRooms(w http.ResponseWriter, r *http.Request) {
 			AvatarURL:        foto,
 			CanonicalAlias:   canal.CanonAlias,
 			NumJoinedMembers: canal.MemberCount,
-			WorldReadable:    false,
+			WorldReadable:    canal.HistoryVisibility == "world_readable",
 			GuestCanJoin:     canal.GuestAccess == "can_join",
 			JoinRule:         &jr,
 		})
 	}
 
-	total := len(chunks)
 	resp := PublicRoomsResponse{
 		Chunk:                  chunks,
 		TotalRoomCountEstimate: &total,

--- a/internal/services/client/rooms/routes_test.go
+++ b/internal/services/client/rooms/routes_test.go
@@ -116,6 +116,7 @@ type MockEventoStore struct {
 	createdEvento   *model.Evento
 	getByTxnIDErr   error
 	getByTxnIDEvent *model.Evento
+	getCurrentStateEventsResult []model.Evento
 }
 
 func (m *MockEventoStore) GetAll(ctx context.Context, filter util.Filter) ([]model.Evento, error) {
@@ -156,6 +157,9 @@ func (m *MockEventoStore) GetMaxGlobalStreamOrdering(ctx context.Context) (int64
 	return 0, nil
 }
 
+func (m *MockEventoStore) GetCurrentStateEvents(ctx context.Context, roomID string) ([]model.Evento, error) {
+	return m.getCurrentStateEventsResult, nil
+}
 // MockNotifier is a mock implementation of notifier.Notifier for testing
 type MockNotifier struct {
 	notifiedUsers map[string]int

--- a/internal/services/client/rooms/routes_test.go
+++ b/internal/services/client/rooms/routes_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
+	"github.com/caio-bernardo/dragonite/internal/repository"
 )
 
 // MockChannelStore is a mock implementation of repository.ChannelStore for testing
@@ -23,6 +24,7 @@ type MockChannelStore struct {
 	getByIDErr           error
 	listPublicResult     []model.Canal
 	listPublicNextBatch  string
+	listPublicTotal      int
 	updateMemberCountErr error
 	upsertEstadoAtualErr error
 }
@@ -49,8 +51,8 @@ func (m *MockChannelStore) Delete(ctx context.Context, id_canal string) (*model.
 	return nil, nil
 }
 
-func (m *MockChannelStore) ListPublic(ctx context.Context, limit int, sinceToken string) ([]model.Canal, string, error) {
-	return m.listPublicResult, m.listPublicNextBatch, nil
+func (m *MockChannelStore) ListPublic(_ context.Context, _ repository.ListPublicParams) ([]model.Canal, string, string, int, error) {
+    return m.listPublicResult, m.listPublicNextBatch, "", m.listPublicTotal, nil
 }
 
 func (m *MockChannelStore) UpdateMemberCount(ctx context.Context, canalID string, delta int) error {

--- a/internal/services/client/routes_test.go
+++ b/internal/services/client/routes_test.go
@@ -221,6 +221,10 @@ func (m *MockEventoStore) GetMaxGlobalStreamOrdering(ctx context.Context) (int64
 	return 0, nil
 }
 
+func (m *MockEventoStore) GetCurrentStateEvents(_ context.Context, _ string) ([]model.Evento, error) {
+    return nil, nil
+}
+
 // MockNotifier é uma implementação mock de notifier.Notifier para testes
 type MockNotifier struct {
 	subscriptions map[string][]chan struct{}

--- a/internal/services/client/routes_test.go
+++ b/internal/services/client/routes_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
+	"github.com/caio-bernardo/dragonite/internal/repository"
 )
 
 // MockUserStore is a mock implementation of repository.UserStore for testing
@@ -116,8 +117,8 @@ func (m *MockChannelStore) Delete(ctx context.Context, id_canal string) (*model.
 	return nil, nil
 }
 
-func (m *MockChannelStore) ListPublic(ctx context.Context, limit int, sinceToken string) ([]model.Canal, string, error) {
-	return []model.Canal{}, "", nil
+func (m *MockChannelStore) ListPublic(_ context.Context, _ repository.ListPublicParams) ([]model.Canal, string, string, int, error) {
+    return nil, "", "", 0, nil
 }
 
 func (m *MockChannelStore) UpdateMemberCount(ctx context.Context, canalID string, delta int) error {
@@ -128,7 +129,6 @@ func (m *MockChannelStore) UpsertEstadoAtual(ctx context.Context, estado *model.
 	return nil
 }
 
-// Implementa repository.UsuarioCanalStore com 8 métodos conforme usuario_canal_store.go
 // Implementa repository.UsuarioCanalStore com 8 métodos conforme usuario_canal_store.go
 
 type MockUsuarioCanalStore struct{}

--- a/internal/services/federation/routes.go
+++ b/internal/services/federation/routes.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"encoding/json"
+	"fmt"
 
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/repository"
@@ -16,14 +17,22 @@ import (
 	"github.com/caio-bernardo/dragonite/internal/util"
 )
 
+// keyFetcherFn permite injetar a busca de chave remota nos testes.
+type keyFetcherFn func(serverName string) (string, ed25519.PublicKey, error)
+
 type Handler struct {
-	config *types.ServerConfig
-	userStore repository.UserStore
-	canalStore repository.ChannelStore
+	config       		*types.ServerConfig
+	userStore 			repository.UserStore
+	canalStore 			repository.ChannelStore
+	eventoStore       	repository.EventoStore
+    usuarioCanalStore 	repository.UsuarioCanalStore
+	keyFetcher          keyFetcherFn
 }
 
-func NewHandler(config *types.ServerConfig, userStore repository.UserStore, canalStore repository.ChannelStore) *Handler {
-	return &Handler{config: config, userStore: userStore, canalStore: canalStore}
+func NewHandler(config *types.ServerConfig, userStore repository.UserStore, canalStore repository.ChannelStore, 
+	eventoStore repository.EventoStore, usuarioCanalStore repository.UsuarioCanalStore) *Handler {
+	return &Handler{config: config, userStore: userStore, canalStore: canalStore, eventoStore: eventoStore, usuarioCanalStore: usuarioCanalStore,
+		keyFetcher: util.FetchRemoteServerKey}
 }
 
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
@@ -32,6 +41,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /_matrix/federation/v1/query/profile", h.getProfile)
 	mux.HandleFunc("GET /_matrix/federation/v1/publicRooms", h.getPublicRooms)
     mux.HandleFunc("POST /_matrix/federation/v1/publicRooms", h.postPublicRooms)
+	mux.HandleFunc("GET /_matrix/federation/v1/make_join/{roomId}/{userId}", h.makeJoin)
+    mux.HandleFunc("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
 }
 
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
@@ -200,4 +211,258 @@ func (h *Handler) writePublicRooms(w http.ResponseWriter, r *http.Request, param
         TotalRoomCountEstimate: &total,
     }
     util.WriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) makeJoin(w http.ResponseWriter, r *http.Request) {
+    roomID := r.PathValue("roomId")
+    userID := r.PathValue("userId")
+
+    // verifica se a sala existe
+    canal, err := h.canalStore.GetByID(r.Context(), roomID)
+    if err != nil {
+        if errors.Is(err, types.ErrNotFound) {
+            util.WriteError(w, http.StatusNotFound, types.NewErrorResponse(types.M_NOT_FOUND, "Unknown room"))
+            return
+        }
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    // verifica compatibilidade de versão da sala.
+    // o parâmetro `ver` é uma lista de versões suportadas pelo servidor remoto, se não informado, assume ["1"].
+    supportedVers := r.URL.Query()["ver"]
+    if len(supportedVers) == 0 {
+        supportedVers = []string{"1"}
+    }
+    roomVersion := canal.Versao
+    versionSupported := false
+    for _, v := range supportedVers {
+        if v == roomVersion {
+            versionSupported = true
+            break
+        }
+    }
+    if !versionSupported {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(
+            types.M_INCOMPATIBLE_ROOM_VERSION,
+            "Your homeserver does not support the features required to join this room",
+        ))
+        return
+    }
+
+    // verifica se a sala permite entrada pública
+    if canal.JoinRules != "public" {
+        util.WriteError(w, http.StatusForbidden, types.NewErrorResponse(types.M_FORBIDDEN, "You are not invited to this room"))
+        return
+    }
+
+    resp := MakeJoinResponse{
+        RoomVersion: roomVersion,
+        Event: EventTemplate{
+            Type:           "m.room.member",
+            Sender:         userID,
+            StateKey:       userID,
+            RoomID:         roomID,
+            Origin:         h.config.ServerName,
+            OriginServerTS: time.Now().UnixMilli(),
+            Content: MembershipContent{
+                Membership: "join",
+            },
+        },
+    }
+
+    util.WriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) sendJoin(w http.ResponseWriter, r *http.Request) {
+    roomID := r.PathValue("roomId")
+
+    // Verifica se a sala existe
+    if _, err := h.canalStore.GetByID(r.Context(), roomID); err != nil {
+        if errors.Is(err, types.ErrNotFound) {
+            util.WriteError(w, http.StatusNotFound, types.NewErrorResponse(types.M_NOT_FOUND, "Unknown room"))
+            return
+        }
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    var req SendJoinRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_BAD_JSON, err.Error()))
+        return
+    }
+
+    // Validações obrigatórias pela spec
+    if req.Type != "m.room.member" {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "event type must be m.room.member"))
+        return
+    }
+    if req.Content.Membership != "join" {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "membership must be join"))
+        return
+    }
+    if req.Sender != req.StateKey {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "sender must equal state_key"))
+        return
+    }
+
+    // Verifica que o sender pertence ao servidor de origem
+    senderParts := strings.SplitN(req.Sender, ":", 2)
+    if len(senderParts) != 2 || senderParts[1] != req.Origin {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "sender must belong to the origin server"))
+        return
+    }
+
+    // Busca e verifica a assinatura ed25519 do servidor de origem
+    if err := h.verifyEventSignature(req); err != nil {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "invalid event signature: "+err.Error()))
+        return
+    }
+
+    // Persiste o evento de membro
+    eventoID := req.EventID
+    if eventoID == "" {
+        eventoID = "$" + req.Sender + ":" + req.Origin
+    }
+    evento := &model.Evento{
+        ID:               eventoID,
+        Tipo:             req.Type,
+        CanalID:          roomID,
+        SenderID:         req.Sender,
+        StateKey:         req.StateKey,
+        Conteudo:         `{"membership":"join"}`,
+        OrigemServidorTS: req.OriginServerTS,
+    }
+    if err := h.eventoStore.Create(r.Context(), evento); err != nil {
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    // Atualiza a membresia do usuário na sala
+    membro := &model.UsuarioCanal{
+        CanalID:   roomID,
+        UsuarioID: req.Sender,
+        Membresia: "join",
+        JoinedAt:  time.Now(),
+    }
+    if err := h.usuarioCanalStore.AddOrUpdateMembership(r.Context(), membro); err != nil {
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    // Atualiza o estado atual da sala
+    estadoMembro := &model.EstadoAtualCanal{
+        CanalID:  roomID,
+        Tipo:     "m.room.member",
+        StateKey: req.Sender,
+        EventoID: eventoID,
+    }
+    if err := h.canalStore.UpsertEstadoAtual(r.Context(), estadoMembro); err != nil {
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+	// Incrementa o contador de membros da sala
+	if err := h.canalStore.UpdateMemberCount(r.Context(), roomID, 1); err != nil {
+    // não fatal, imprime no console mas não falha o join
+    fmt.Printf("[WARN] sendJoin: failed to update member count for %s: %v\n", roomID, err)
+	}
+
+    // Busca o estado atual para incluir na resposta
+    stateEventos, err := h.eventoStore.GetCurrentStateEvents(r.Context(), roomID)
+    if err != nil {
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    statePDUs := eventosToPDUs(stateEventos)
+
+    // Servidores ativos na sala (para servers_in_room)
+    userIDs, _ := h.usuarioCanalStore.GetJoinedUserIDsInRoom(r.Context(), roomID)
+    servers := extractServers(userIDs)
+
+    resp := SendJoinResponse{
+        State:     statePDUs,
+        AuthChain: statePDUs, // simplificação: auth chain = estado atual
+    }
+    if len(servers) > 0 {
+        resp.ServersInRoom = servers
+    }
+
+    util.WriteJSON(w, http.StatusOK, resp)
+}
+
+// verifyEventSignature verifica a assinatura ed25519 do PDU recebido.
+func (h *Handler) verifyEventSignature(req SendJoinRequest) error {
+    serverSigs, ok := req.Signatures[req.Origin]
+    if !ok {
+        return fmt.Errorf("no signature from origin server %s", req.Origin)
+    }
+
+    keyID, pubKey, err := h.keyFetcher(req.Origin)
+    if err != nil {
+        return fmt.Errorf("could not fetch public key: %w", err)
+    }
+
+    sig, ok := serverSigs[keyID]
+    if !ok {
+        return fmt.Errorf("no signature for key %s", keyID)
+    }
+
+    sigBytes, err := base64.RawStdEncoding.DecodeString(sig)
+    if err != nil {
+        return fmt.Errorf("invalid signature encoding: %w", err)
+    }
+
+    // Reconstrói o payload sem signatures e unsigned para verificar
+    payload := map[string]interface{}{
+        "content":          req.Content,
+        "origin":           req.Origin,
+        "origin_server_ts": req.OriginServerTS,
+        "room_id":          req.RoomID,
+        "sender":           req.Sender,
+        "state_key":        req.StateKey,
+        "type":             req.Type,
+    }
+    canonical, err := util.CanonicalJSON(payload)
+    if err != nil {
+        return fmt.Errorf("failed to canonicalize event: %w", err)
+    }
+
+    if !ed25519.Verify(pubKey, canonical, sigBytes) {
+        return fmt.Errorf("signature verification failed")
+    }
+    return nil
+}
+
+// eventosToPDUs converte eventos internos para o formato StatePDU da spec.
+func eventosToPDUs(eventos []model.Evento) []StatePDU {
+    pdus := make([]StatePDU, 0, len(eventos))
+    for _, e := range eventos {
+        pdus = append(pdus, StatePDU{
+            EventID:        e.ID,
+            Type:           e.Tipo,
+            RoomID:         e.CanalID,
+            Sender:         e.SenderID,
+            StateKey:       e.StateKey,
+            OriginServerTS: e.OrigemServidorTS,
+            Content:        json.RawMessage(e.Conteudo),
+        })
+    }
+    return pdus
+}
+
+// extractServers extrai os server names únicos a partir de uma lista de user IDs.
+func extractServers(userIDs []string) []string {
+    seen := make(map[string]bool)
+    servers := make([]string, 0)
+    for _, uid := range userIDs {
+        parts := strings.SplitN(uid, ":", 2)
+        if len(parts) == 2 && !seen[parts[1]] {
+            seen[parts[1]] = true
+            servers = append(servers, parts[1])
+        }
+    }
+    return servers
 }

--- a/internal/services/federation/routes.go
+++ b/internal/services/federation/routes.go
@@ -3,24 +3,30 @@ package federation
 import (
 	"crypto/ed25519"
 	"encoding/base64"
-	"net/http"
+	"errors"
 	"time"
+	"strings"
+	"net/http"
 
+	"github.com/caio-bernardo/dragonite/internal/model"
+	"github.com/caio-bernardo/dragonite/internal/repository"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
 )
 
 type Handler struct {
 	config *types.ServerConfig
+	userStore repository.UserStore
 }
 
-func NewHandler(config *types.ServerConfig) *Handler {
-	return &Handler{config: config}
+func NewHandler(config *types.ServerConfig, userStore repository.UserStore) *Handler {
+	return &Handler{config: config, userStore: userStore}
 }
 
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /_matrix/federation/v1/version", h.getVersion)
 	mux.HandleFunc("GET /_matrix/key/v2/server", h.getServerKey)
+	mux.HandleFunc("GET /_matrix/federation/v1/query/profile", h.getProfile)
 }
 
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
@@ -60,4 +66,52 @@ func (h *Handler) getServerKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.WriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) getProfile(w http.ResponseWriter, r *http.Request) {
+	userID := r.URL.Query().Get("user_id")
+	if userID == "" {
+		util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_MISSING_PARAM, "user_id is required"))
+		return
+	}
+
+	// Homeservers devem apenas responder por usuários locais.
+	// O server name fica após o ":" no Matrix user ID (@localpart:server_name).
+	parts := strings.SplitN(userID, ":", 2)
+	if len(parts) != 2 || parts[1] != h.config.ServerName {
+		util.WriteError(w, http.StatusNotFound, types.NewErrorResponse(types.M_NOT_FOUND, "User does not exist."))
+		return
+	}
+
+	field := r.URL.Query().Get("field")
+	if field != "" && field != "displayname" && field != "avatar_url" {
+		util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_INVALID_PARAM, "field must be 'displayname' or 'avatar_url'"))
+		return
+	}
+
+	usuario, err := h.userStore.GetNameAndPhotoByID(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, types.ErrNotFound) {
+			util.WriteError(w, http.StatusNotFound, types.NewErrorResponse(types.M_NOT_FOUND, "User does not exist."))
+			return
+		}
+		util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+		return
+	}
+
+	res := model.ProfileResponse{
+		DisplayName: usuario.Nome,
+		AvatarURL:   usuario.Foto,
+	}
+
+	// Se um field específico foi pedido, zeramos o outro.
+	// Os tags omitempty no ProfileResponse garantem que campos vazios não apareçam no JSON
+	switch field {
+	case "displayname":
+		res.AvatarURL = ""
+	case "avatar_url":
+		res.DisplayName = ""
+	}
+
+	util.WriteJSON(w, http.StatusOK, res)
 }

--- a/internal/services/federation/routes.go
+++ b/internal/services/federation/routes.go
@@ -7,6 +7,8 @@ import (
 	"time"
 	"strings"
 	"net/http"
+	"strconv"
+	"encoding/json"
 
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/repository"
@@ -17,16 +19,19 @@ import (
 type Handler struct {
 	config *types.ServerConfig
 	userStore repository.UserStore
+	canalStore repository.ChannelStore
 }
 
-func NewHandler(config *types.ServerConfig, userStore repository.UserStore) *Handler {
-	return &Handler{config: config, userStore: userStore}
+func NewHandler(config *types.ServerConfig, userStore repository.UserStore, canalStore repository.ChannelStore) *Handler {
+	return &Handler{config: config, userStore: userStore, canalStore: canalStore}
 }
 
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /_matrix/federation/v1/version", h.getVersion)
 	mux.HandleFunc("GET /_matrix/key/v2/server", h.getServerKey)
 	mux.HandleFunc("GET /_matrix/federation/v1/query/profile", h.getProfile)
+	mux.HandleFunc("GET /_matrix/federation/v1/publicRooms", h.getPublicRooms)
+    mux.HandleFunc("POST /_matrix/federation/v1/publicRooms", h.postPublicRooms)
 }
 
 func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
@@ -114,4 +119,85 @@ func (h *Handler) getProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	util.WriteJSON(w, http.StatusOK, res)
+}
+
+// canalToChunk converte um Canal para o formato PublishedRoomsChunk da spec Matrix.
+// guest_can_join e world_readable são derivados dos campos de estado da sala.
+func canalToChunk(c model.Canal) PublishedRoomsChunk {
+    chunk := PublishedRoomsChunk{
+        RoomID:           c.ID,
+        NumJoinedMembers: c.MemberCount,
+        GuestCanJoin:     c.GuestAccess == "can_join",
+        WorldReadable:    c.HistoryVisibility == "world_readable",
+        Name:             c.Nome,
+        Topic:            c.Descricao,
+        AvatarURL:        c.Foto,
+        JoinRule:         c.JoinRules,
+    }
+    if c.CanonAlias != nil {
+        chunk.CanonicalAlias = *c.CanonAlias
+    }
+    if c.RoomType != nil {
+        chunk.RoomType = *c.RoomType
+    }
+    return chunk
+}
+
+func (h *Handler) getPublicRooms(w http.ResponseWriter, r *http.Request) {
+    q := r.URL.Query()
+
+    limit := 0
+    if s := q.Get("limit"); s != "" {
+        if v, err := strconv.Atoi(s); err == nil {
+            limit = v
+        }
+    }
+
+    params := repository.ListPublicParams{
+        Limit:      limit,
+        SinceToken: q.Get("since"),
+    }
+
+    h.writePublicRooms(w, r, params)
+}
+
+func (h *Handler) postPublicRooms(w http.ResponseWriter, r *http.Request) {
+    var req PublicRoomsRequest
+    if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+        util.WriteError(w, http.StatusBadRequest, types.NewErrorResponse(types.M_BAD_JSON, err.Error()))
+        return
+    }
+
+    params := repository.ListPublicParams{
+        Limit:      req.Limit,
+        SinceToken: req.Since,
+    }
+    if req.Filter != nil {
+        params.SearchTerm = req.Filter.GenericSearchTerm
+        params.RoomTypes = req.Filter.RoomTypes
+    }
+
+    h.writePublicRooms(w, r, params)
+}
+
+// writePublicRooms executa a busca e escreve a resposta, compartilhado entre GET e POST
+func (h *Handler) writePublicRooms(w http.ResponseWriter, r *http.Request, params repository.ListPublicParams) {
+    canais, nextBatch, prevBatch, total, err := h.canalStore.ListPublic(r.Context(), params)
+    if err != nil {
+        util.WriteError(w, http.StatusInternalServerError, types.NewErrorResponse(types.M_UNKNOWN, err.Error()))
+        return
+    }
+
+    chunks := make([]PublishedRoomsChunk, 0, len(canais))
+    for _, c := range canais {
+        chunks = append(chunks, canalToChunk(c))
+    }
+
+    resp := PublicRoomsResponse{
+        Chunk:                  chunks,
+        NextBatch:              nextBatch,
+        PrevBatch:              prevBatch,
+        TotalRoomCountEstimate: &total,
+    }
+    util.WriteJSON(w, http.StatusOK, resp)
 }

--- a/internal/services/federation/routest_test.go
+++ b/internal/services/federation/routest_test.go
@@ -1,6 +1,7 @@
 package federation
 
 import (
+	"context"
 	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
@@ -11,10 +12,43 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
 	_ "github.com/joho/godotenv/autoload"
 )
+
+type mockUserStore struct {
+	users map[string]*model.Usuario
+}
+
+func newMockUserStore(users ...*model.Usuario) *mockUserStore {
+	m := &mockUserStore{users: make(map[string]*model.Usuario)}
+	for _, u := range users {
+		m.users[u.ID] = u
+	}
+	return m
+}
+
+func (m *mockUserStore) GetNameAndPhotoByID(_ context.Context, id string) (*model.Usuario, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, types.ErrNotFound
+	}
+	return u, nil
+}
+
+// Stubs para satisfazer a interface UserStore
+func (m *mockUserStore) GetAll(_ context.Context, _ util.Filter) ([]model.Usuario, error)          { return nil, nil }
+func (m *mockUserStore) GetByID(_ context.Context, _ string) (*model.Usuario, error)               { return nil, nil }
+func (m *mockUserStore) GetByLocal(_ context.Context, _ string) (*model.Usuario, error)            { return nil, nil }
+func (m *mockUserStore) Create(_ context.Context, _ *model.Usuario) error                          { return nil }
+func (m *mockUserStore) Update(_ context.Context, _ *model.Usuario) error                          { return nil }
+func (m *mockUserStore) Delete(_ context.Context, _ string) (*model.Usuario, error)                { return nil, nil }
+func (m *mockUserStore) Search(_ context.Context, _ string, _ int) ([]model.Usuario, error)        { return nil, nil }
+func (m *mockUserStore) ClearProfileKey(_ context.Context, _ string, _ string) error               { return nil }
+func (m *mockUserStore) UpdateProfileKey(_ context.Context, _ string, _ string, _ string) error    { return nil }
+
 
 func MockConfig() types.ServerConfig {
 	publicKey, privateKey, _ := ed25519.GenerateKey(nil)
@@ -27,13 +61,13 @@ func MockConfig() types.ServerConfig {
 	}
 }
 
-func NewTestHandler() *Handler {
-	config := MockConfig()
-	return NewHandler(&config)
+func NewTestHandler(userStore *mockUserStore) *Handler {
+    config := MockConfig()
+    return NewHandler(&config, userStore)
 }
 
 func TestFederationVersion(t *testing.T) {
-	h := NewTestHandler()
+	h := NewTestHandler(newMockUserStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getVersion))
 	defer server.Close()
 
@@ -59,7 +93,7 @@ func TestFederationVersion(t *testing.T) {
 }
 
 func TestGetKeyServer(t *testing.T) {
-	h := NewTestHandler()
+	h := NewTestHandler(newMockUserStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getServerKey))
 	defer server.Close()
 
@@ -73,36 +107,214 @@ func TestGetKeyServer(t *testing.T) {
 		t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
 	}
 
-	var mockBody ServerKeyResponse
-	mockBody.ServerName = h.config.ServerName
-	// Validade de 1 ano
-	mockBody.ValidUntilTS = time.Now().Add(365 * 24 * time.Hour).UnixMilli()
-	publicKey := base64.RawStdEncoding.EncodeToString(h.config.PublicKey)
-	mockBody.VerifyKeys = map[string]VerifyKey{
-		h.config.KeyID: {
-			Key: publicKey,
-		},
-	}
+	var body ServerKeyResponse
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        t.Fatal(err)
+    }
 
-	// Criptografia
-	canonicalJson, _ := util.CanonicalJSON(mockBody)
+    // Verifica campos estáticos
+    if body.ServerName != h.config.ServerName {
+        t.Errorf("expected server_name %q, got %q", h.config.ServerName, body.ServerName)
+    }
 
-	signatureBytes := ed25519.Sign(h.config.PrivateKey, canonicalJson)
-	signatureBase64 := base64.RawStdEncoding.EncodeToString(signatureBytes)
+    verifyKey, ok := body.VerifyKeys[h.config.KeyID]
+    if !ok {
+        t.Fatalf("expected verify key %q not found", h.config.KeyID)
+    }
+    expectedKey := base64.RawStdEncoding.EncodeToString(h.config.PublicKey)
+    if verifyKey.Key != expectedKey {
+        t.Errorf("expected key %q, got %q", expectedKey, verifyKey.Key)
+    }
 
-	// add signature
-	mockBody.Signatures = map[string]map[string]string{
-		h.config.ServerName: {
-			h.config.KeyID: signatureBase64,
-		},
-	}
-	expectBody, _ := json.Marshal(mockBody)
+    // Verifica que valid_until_ts é aproximadamente 1 ano (margem de 5s)
+    expectedTS := time.Now().Add(365 * 24 * time.Hour).UnixMilli()
+    diff := body.ValidUntilTS - expectedTS
+    if diff < -5000 || diff > 5000 {
+        t.Errorf("valid_until_ts %d fora do esperado (~%d)", body.ValidUntilTS, expectedTS)
+    }
 
-	body, err := io.ReadAll(resp.Body)
+    // Verifica a assinatura criptograficamente:
+    // extrai a assinatura, reconstrói o JSON sem ela, e valida
+    sig, ok := body.Signatures[h.config.ServerName][h.config.KeyID]
+    if !ok {
+        t.Fatal("assinatura não encontrada na resposta")
+    }
+    sigBytes, err := base64.RawStdEncoding.DecodeString(sig)
+    if err != nil {
+        t.Fatalf("erro ao decodificar assinatura: %v", err)
+    }
+
+    // Remove as signatures para reconstruir o payload que foi assinado
+    bodyWithoutSig := body
+    bodyWithoutSig.Signatures = nil
+    canonical, err := util.CanonicalJSON(bodyWithoutSig)
+    if err != nil {
+        t.Fatalf("erro ao gerar canonical JSON: %v", err)
+    }
+
+    if !ed25519.Verify(h.config.PublicKey, canonical, sigBytes) {
+        t.Error("assinatura inválida")
+    }
+}
+
+// Testes do getProfile 
+
+func TestGetProfile_MissingUserID(t *testing.T) {
+	h := NewTestHandler(newMockUserStore())
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(body) != string(expectBody) {
-		t.Errorf("expected body %s, got %s", expectBody, string(body))
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetProfile_NonLocalUser(t *testing.T) {
+	h := NewTestHandler(newMockUserStore())
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:matrix.org")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetProfile_InvalidField(t *testing.T) {
+	h := NewTestHandler(newMockUserStore())
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:dragonite.com&field=invalid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetProfile_UserNotFound(t *testing.T) {
+	h := NewTestHandler(newMockUserStore()) // store vazio
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:dragonite.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestGetProfile_FullProfile(t *testing.T) {
+	usuario := &model.Usuario{
+		ID:   "@alice:dragonite.com",
+		Nome: "Alice",
+		Foto: "mxc://dragonite.com/abc123",
+	}
+	h := NewTestHandler(newMockUserStore(usuario))
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:dragonite.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body model.ProfileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.DisplayName != "Alice" {
+		t.Errorf("expected displayname 'Alice', got '%s'", body.DisplayName)
+	}
+	if body.AvatarURL != "mxc://dragonite.com/abc123" {
+		t.Errorf("expected avatar_url 'mxc://dragonite.com/abc123', got '%s'", body.AvatarURL)
+	}
+}
+
+func TestGetProfile_OnlyDisplayName(t *testing.T) {
+	usuario := &model.Usuario{
+		ID:   "@alice:dragonite.com",
+		Nome: "Alice",
+		Foto: "mxc://dragonite.com/abc123",
+	}
+	h := NewTestHandler(newMockUserStore(usuario))
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:dragonite.com&field=displayname")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body model.ProfileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.DisplayName != "Alice" {
+		t.Errorf("expected displayname 'Alice', got '%s'", body.DisplayName)
+	}
+	if body.AvatarURL != "" {
+		t.Errorf("expected avatar_url to be absent, got '%s'", body.AvatarURL)
+	}
+}
+
+func TestGetProfile_OnlyAvatarURL(t *testing.T) {
+	usuario := &model.Usuario{
+		ID:   "@alice:dragonite.com",
+		Nome: "Alice",
+		Foto: "mxc://dragonite.com/abc123",
+	}
+	h := NewTestHandler(newMockUserStore(usuario))
+	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?user_id=@alice:dragonite.com&field=avatar_url")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body model.ProfileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.AvatarURL != "mxc://dragonite.com/abc123" {
+		t.Errorf("expected avatar_url 'mxc://dragonite.com/abc123', got '%s'", body.AvatarURL)
+	}
+	if body.DisplayName != "" {
+		t.Errorf("expected displayname to be absent, got '%s'", body.DisplayName)
 	}
 }

--- a/internal/services/federation/routest_test.go
+++ b/internal/services/federation/routest_test.go
@@ -11,12 +11,17 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+	"strings"
+	"bytes"
 
 	"github.com/caio-bernardo/dragonite/internal/model"
+	"github.com/caio-bernardo/dragonite/internal/repository"
 	"github.com/caio-bernardo/dragonite/internal/types"
 	"github.com/caio-bernardo/dragonite/internal/util"
 	_ "github.com/joho/godotenv/autoload"
 )
+
+// --- Mock UserStore ---
 
 type mockUserStore struct {
 	users map[string]*model.Usuario
@@ -49,6 +54,69 @@ func (m *mockUserStore) Search(_ context.Context, _ string, _ int) ([]model.Usua
 func (m *mockUserStore) ClearProfileKey(_ context.Context, _ string, _ string) error               { return nil }
 func (m *mockUserStore) UpdateProfileKey(_ context.Context, _ string, _ string, _ string) error    { return nil }
 
+// --- Mock CanalStore ---
+
+type mockCanalStore struct {
+	canais []model.Canal
+}
+
+func newMockCanalStore(canais ...model.Canal) *mockCanalStore {
+	return &mockCanalStore{canais: canais}
+}
+
+func (m *mockCanalStore) ListPublic(_ context.Context, params repository.ListPublicParams) ([]model.Canal, string, string, int, error) {
+	// Filtra canais públicos com optional search term
+	filtered := make([]model.Canal, 0)
+	for _, c := range m.canais {
+		if !c.IsPublic {
+			continue
+		}
+		if params.SearchTerm != "" {
+			term := strings.ToLower(params.SearchTerm)
+			if !strings.Contains(strings.ToLower(c.Nome), term) &&
+				!strings.Contains(strings.ToLower(c.Descricao), term) {
+				continue
+			}
+		}
+		filtered = append(filtered, c)
+	}
+
+	total := len(filtered)
+
+	offset := 0
+	if params.SinceToken != "" {
+		fmt.Sscanf(params.SinceToken, "%d", &offset)
+	}
+	if offset > len(filtered) {
+		offset = len(filtered)
+	}
+	filtered = filtered[offset:]
+
+	nextBatch := ""
+	if params.Limit > 0 && len(filtered) > params.Limit {
+		filtered = filtered[:params.Limit]
+		nextBatch = fmt.Sprintf("%d", offset+params.Limit)
+	}
+
+	prevBatch := ""
+	if offset > 0 && params.Limit > 0 {
+		if prev := offset - params.Limit; prev >= 0 {
+			prevBatch = fmt.Sprintf("%d", prev)
+		}
+	}
+
+	return filtered, nextBatch, prevBatch, total, nil
+}
+
+func (m *mockCanalStore) GetAll(_ context.Context, _ util.Filter) ([]model.Canal, error)             { return nil, nil }
+func (m *mockCanalStore) GetByID(_ context.Context, _ string) (*model.Canal, error)                  { return nil, nil }
+func (m *mockCanalStore) Create(_ context.Context, _ *model.Canal) error                             { return nil }
+func (m *mockCanalStore) Update(_ context.Context, _ *model.Canal) error                             { return nil }
+func (m *mockCanalStore) Delete(_ context.Context, _ string) (*model.Canal, error)                   { return nil, nil }
+func (m *mockCanalStore) UpdateMemberCount(_ context.Context, _ string, _ int) error                 { return nil }
+func (m *mockCanalStore) UpsertEstadoAtual(_ context.Context, _ *model.EstadoAtualCanal) error       { return nil }
+
+// Helpers
 
 func MockConfig() types.ServerConfig {
 	publicKey, privateKey, _ := ed25519.GenerateKey(nil)
@@ -61,13 +129,15 @@ func MockConfig() types.ServerConfig {
 	}
 }
 
-func NewTestHandler(userStore *mockUserStore) *Handler {
+func NewTestHandler(userStore *mockUserStore, canalStore *mockCanalStore) *Handler {
     config := MockConfig()
-    return NewHandler(&config, userStore)
+    return NewHandler(&config, userStore, canalStore)
 }
 
+// --- Testes existentes ---
+
 func TestFederationVersion(t *testing.T) {
-	h := NewTestHandler(newMockUserStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getVersion))
 	defer server.Close()
 
@@ -93,7 +163,7 @@ func TestFederationVersion(t *testing.T) {
 }
 
 func TestGetKeyServer(t *testing.T) {
-	h := NewTestHandler(newMockUserStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getServerKey))
 	defer server.Close()
 
@@ -160,7 +230,7 @@ func TestGetKeyServer(t *testing.T) {
 // Testes do getProfile 
 
 func TestGetProfile_MissingUserID(t *testing.T) {
-	h := NewTestHandler(newMockUserStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -176,7 +246,7 @@ func TestGetProfile_MissingUserID(t *testing.T) {
 }
 
 func TestGetProfile_NonLocalUser(t *testing.T) {
-	h := NewTestHandler(newMockUserStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -192,7 +262,7 @@ func TestGetProfile_NonLocalUser(t *testing.T) {
 }
 
 func TestGetProfile_InvalidField(t *testing.T) {
-	h := NewTestHandler(newMockUserStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -208,7 +278,7 @@ func TestGetProfile_InvalidField(t *testing.T) {
 }
 
 func TestGetProfile_UserNotFound(t *testing.T) {
-	h := NewTestHandler(newMockUserStore()) // store vazio
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore()) // store vazio
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -229,7 +299,7 @@ func TestGetProfile_FullProfile(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario))
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -261,7 +331,7 @@ func TestGetProfile_OnlyDisplayName(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario))
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -293,7 +363,7 @@ func TestGetProfile_OnlyAvatarURL(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario))
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -316,5 +386,201 @@ func TestGetProfile_OnlyAvatarURL(t *testing.T) {
 	}
 	if body.DisplayName != "" {
 		t.Errorf("expected displayname to be absent, got '%s'", body.DisplayName)
+	}
+}
+
+// --- Testes getPublicRooms ---
+
+func TestGetPublicRooms_Empty(t *testing.T) {
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body PublicRoomsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Chunk) != 0 {
+		t.Errorf("expected empty chunk, got %d items", len(body.Chunk))
+	}
+}
+
+func TestGetPublicRooms_WithRooms(t *testing.T) {
+	roomType := "m.space"
+	canais := []model.Canal{
+		{
+			ID: "!room1:dragonite.com", Nome: "General", Descricao: "General chat",
+			IsPublic: true, JoinRules: "public", GuestAccess: "can_join",
+			HistoryVisibility: "world_readable", MemberCount: 10, RoomType: &roomType,
+		},
+		{
+			ID: "!room2:dragonite.com", Nome: "Off-Topic", IsPublic: true,
+			JoinRules: "public", GuestAccess: "forbidden",
+			HistoryVisibility: "shared", MemberCount: 3,
+		},
+	}
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body PublicRoomsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Chunk) != 2 {
+		t.Fatalf("expected 2 rooms, got %d", len(body.Chunk))
+	}
+	// Verifica conversão de campos
+	first := body.Chunk[0]
+	if first.RoomID != "!room1:dragonite.com" {
+		t.Errorf("expected room1, got %s", first.RoomID)
+	}
+	if !first.GuestCanJoin {
+		t.Error("expected guest_can_join true")
+	}
+	if !first.WorldReadable {
+		t.Error("expected world_readable true")
+	}
+	if first.RoomType != "m.space" {
+		t.Errorf("expected room_type 'm.space', got %q", first.RoomType)
+	}
+	// Segunda sala: guest_can_join e world_readable devem ser false
+	second := body.Chunk[1]
+	if second.GuestCanJoin {
+		t.Error("expected guest_can_join false")
+	}
+	if second.WorldReadable {
+		t.Error("expected world_readable false")
+	}
+}
+
+func TestGetPublicRooms_Pagination(t *testing.T) {
+	canais := []model.Canal{
+		{ID: "!r1:dragonite.com", Nome: "Room 1", IsPublic: true, MemberCount: 3},
+		{ID: "!r2:dragonite.com", Nome: "Room 2", IsPublic: true, MemberCount: 2},
+		{ID: "!r3:dragonite.com", Nome: "Room 3", IsPublic: true, MemberCount: 1},
+	}
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "?limit=2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var body PublicRoomsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Chunk) != 2 {
+		t.Fatalf("expected 2 rooms, got %d", len(body.Chunk))
+	}
+	if body.NextBatch == "" {
+		t.Error("expected next_batch to be set")
+	}
+	if body.PrevBatch != "" {
+		t.Errorf("expected prev_batch absent na primeira página, got %q", body.PrevBatch)
+	}
+}
+
+// --- Testes postPublicRooms ---
+
+func TestPostPublicRooms_BadJSON(t *testing.T) {
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString("{invalid json}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestPostPublicRooms_WithFilter(t *testing.T) {
+	canais := []model.Canal{
+		{ID: "!cheese:dragonite.com", Nome: "Cheese Lovers", IsPublic: true, MemberCount: 10},
+		{ID: "!code:dragonite.com", Nome: "Coding Talk", IsPublic: true, MemberCount: 5},
+	}
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
+	defer server.Close()
+
+	reqBody, _ := json.Marshal(PublicRoomsRequest{
+		Filter: &PublicRoomsFilter{GenericSearchTerm: "cheese"},
+	})
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBuffer(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body PublicRoomsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Chunk) != 1 {
+		t.Fatalf("expected 1 room após filtro, got %d", len(body.Chunk))
+	}
+	if body.Chunk[0].RoomID != "!cheese:dragonite.com" {
+		t.Errorf("expected cheese room, got %s", body.Chunk[0].RoomID)
+	}
+}
+
+func TestPostPublicRooms_EmptyBody(t *testing.T) {
+	canais := []model.Canal{
+		{ID: "!r1:dragonite.com", Nome: "Room 1", IsPublic: true, MemberCount: 5},
+	}
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
+	defer server.Close()
+
+	// Body vazio é válido — equivale a POST sem filtros
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBufferString("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body PublicRoomsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if len(body.Chunk) != 1 {
+		t.Fatalf("expected 1 room, got %d", len(body.Chunk))
 	}
 }

--- a/internal/services/federation/routest_test.go
+++ b/internal/services/federation/routest_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"strings"
 	"bytes"
+	"net/url"
 
 	"github.com/caio-bernardo/dragonite/internal/model"
 	"github.com/caio-bernardo/dragonite/internal/repository"
@@ -109,12 +110,65 @@ func (m *mockCanalStore) ListPublic(_ context.Context, params repository.ListPub
 }
 
 func (m *mockCanalStore) GetAll(_ context.Context, _ util.Filter) ([]model.Canal, error)             { return nil, nil }
-func (m *mockCanalStore) GetByID(_ context.Context, _ string) (*model.Canal, error)                  { return nil, nil }
+
+func (m *mockCanalStore) GetByID(_ context.Context, id string) (*model.Canal, error) {
+    for i, c := range m.canais {
+        if c.ID == id {
+            return &m.canais[i], nil
+        }
+    }
+    return nil, types.ErrNotFound
+}
+
 func (m *mockCanalStore) Create(_ context.Context, _ *model.Canal) error                             { return nil }
 func (m *mockCanalStore) Update(_ context.Context, _ *model.Canal) error                             { return nil }
 func (m *mockCanalStore) Delete(_ context.Context, _ string) (*model.Canal, error)                   { return nil, nil }
 func (m *mockCanalStore) UpdateMemberCount(_ context.Context, _ string, _ int) error                 { return nil }
 func (m *mockCanalStore) UpsertEstadoAtual(_ context.Context, _ *model.EstadoAtualCanal) error       { return nil }
+
+// --- Mock EventoStore ---
+
+type mockEventoStore struct {
+    stateEventos []model.Evento
+    createErr    error
+}
+
+func (m *mockEventoStore) Create(_ context.Context, _ *model.Evento) error {
+    return m.createErr
+}
+
+func (m *mockEventoStore) GetCurrentStateEvents(_ context.Context, _ string) ([]model.Evento, error) {
+    return m.stateEventos, nil
+}
+
+func (m *mockEventoStore) GetAll(_ context.Context, _ util.Filter) ([]model.Evento, error)                          { return nil, nil }
+func (m *mockEventoStore) GetByID(_ context.Context, _ string) (*model.Evento, error)                               { return nil, nil }
+func (m *mockEventoStore) GetByTxnID(_ context.Context, _, _ string) (*model.Evento, error)                         { return nil, nil }
+func (m *mockEventoStore) Update(_ context.Context, _ *model.Evento) error                                          { return nil }
+func (m *mockEventoStore) Delete(_ context.Context, _ string) (*model.Evento, error)                                { return nil, nil }
+func (m *mockEventoStore) CheckNew(_ context.Context, _ string, _ model.SyncToken) (bool, error)                    { return false, nil }
+func (m *mockEventoStore) GetSince(_ context.Context, _ string, t model.SyncToken) ([]model.Evento, model.SyncToken, error) { return nil, t, nil }
+func (m *mockEventoStore) GetMaxGlobalStreamOrdering(_ context.Context) (int64, error)                              { return 0, nil }
+
+// --- Mock UsuarioCanalStore ---
+
+type mockUsuarioCanalStore struct {
+    members []string
+}
+
+func (m *mockUsuarioCanalStore) AddOrUpdateMembership(_ context.Context, _ *model.UsuarioCanal) error { return nil }
+
+func (m *mockUsuarioCanalStore) GetJoinedUserIDsInRoom(_ context.Context, _ string) ([]string, error) {
+    return m.members, nil
+}
+
+func (m *mockUsuarioCanalStore) GetAll(_ context.Context, _ util.Filter) ([]model.UsuarioCanal, error)           { return nil, nil }
+func (m *mockUsuarioCanalStore) GetByComposedID(_ context.Context, _, _ string) (*model.UsuarioCanal, error)     { return nil, nil }
+func (m *mockUsuarioCanalStore) GetAllByUsuarioID(_ context.Context, _ string) ([]model.UsuarioCanal, error)     { return nil, nil }
+func (m *mockUsuarioCanalStore) GetAllByCanalID(_ context.Context, _ string) ([]model.UsuarioCanal, error)       { return nil, nil }
+func (m *mockUsuarioCanalStore) Create(_ context.Context, _ *model.UsuarioCanal) error                         	 { return nil }
+func (m *mockUsuarioCanalStore) Update(_ context.Context, _ *model.UsuarioCanal) error                         	 { return nil }
+func (m *mockUsuarioCanalStore) Delete(_ context.Context, _, _ string) (*model.UsuarioCanal, error)              { return nil, nil }
 
 // Helpers
 
@@ -129,15 +183,46 @@ func MockConfig() types.ServerConfig {
 	}
 }
 
-func NewTestHandler(userStore *mockUserStore, canalStore *mockCanalStore) *Handler {
+// signJoinRequest assina um SendJoinRequest com a chave privada fornecida.
+func signJoinRequest(t *testing.T, privKey ed25519.PrivateKey, keyID string, req SendJoinRequest) SendJoinRequest {
+    t.Helper()
+    payload := map[string]interface{}{
+        "content":          req.Content,
+        "origin":           req.Origin,
+        "origin_server_ts": req.OriginServerTS,
+        "room_id":          req.RoomID,
+        "sender":           req.Sender,
+        "state_key":        req.StateKey,
+        "type":             req.Type,
+    }
+    canonical, err := util.CanonicalJSON(payload)
+    if err != nil {
+        t.Fatalf("signJoinRequest: failed to canonicalize: %v", err)
+    }
+    sig := base64.RawStdEncoding.EncodeToString(ed25519.Sign(privKey, canonical))
+    req.Signatures = map[string]map[string]string{
+        req.Origin: {keyID: sig},
+    }
+    return req
+}
+
+// newMuxServer cria um httptest.Server com o handler registrado no padrão correto.
+// Necessário para testes de handlers que usam r.PathValue().
+func newMuxServer(pattern string, h http.HandlerFunc) *httptest.Server {
+    mux := http.NewServeMux()
+    mux.HandleFunc(pattern, h)
+    return httptest.NewServer(mux)
+}
+
+func NewTestHandler(userStore *mockUserStore, canalStore *mockCanalStore, eventoStore *mockEventoStore, ucStore *mockUsuarioCanalStore) *Handler {
     config := MockConfig()
-    return NewHandler(&config, userStore, canalStore)
+    return NewHandler(&config, userStore, canalStore, eventoStore, ucStore)
 }
 
 // --- Testes existentes ---
 
 func TestFederationVersion(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getVersion))
 	defer server.Close()
 
@@ -163,7 +248,7 @@ func TestFederationVersion(t *testing.T) {
 }
 
 func TestGetKeyServer(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getServerKey))
 	defer server.Close()
 
@@ -230,7 +315,7 @@ func TestGetKeyServer(t *testing.T) {
 // Testes do getProfile 
 
 func TestGetProfile_MissingUserID(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -246,7 +331,7 @@ func TestGetProfile_MissingUserID(t *testing.T) {
 }
 
 func TestGetProfile_NonLocalUser(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -262,7 +347,7 @@ func TestGetProfile_NonLocalUser(t *testing.T) {
 }
 
 func TestGetProfile_InvalidField(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -278,7 +363,7 @@ func TestGetProfile_InvalidField(t *testing.T) {
 }
 
 func TestGetProfile_UserNotFound(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore()) // store vazio
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil) // store vazio
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -299,7 +384,7 @@ func TestGetProfile_FullProfile(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -331,7 +416,7 @@ func TestGetProfile_OnlyDisplayName(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -363,7 +448,7 @@ func TestGetProfile_OnlyAvatarURL(t *testing.T) {
 		Nome: "Alice",
 		Foto: "mxc://dragonite.com/abc123",
 	}
-	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(usuario), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getProfile))
 	defer server.Close()
 
@@ -392,7 +477,7 @@ func TestGetProfile_OnlyAvatarURL(t *testing.T) {
 // --- Testes getPublicRooms ---
 
 func TestGetPublicRooms_Empty(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
 	defer server.Close()
 
@@ -429,7 +514,7 @@ func TestGetPublicRooms_WithRooms(t *testing.T) {
 			HistoryVisibility: "shared", MemberCount: 3,
 		},
 	}
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
 	defer server.Close()
 
@@ -480,7 +565,7 @@ func TestGetPublicRooms_Pagination(t *testing.T) {
 		{ID: "!r2:dragonite.com", Nome: "Room 2", IsPublic: true, MemberCount: 2},
 		{ID: "!r3:dragonite.com", Nome: "Room 3", IsPublic: true, MemberCount: 1},
 	}
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.getPublicRooms))
 	defer server.Close()
 
@@ -508,7 +593,7 @@ func TestGetPublicRooms_Pagination(t *testing.T) {
 // --- Testes postPublicRooms ---
 
 func TestPostPublicRooms_BadJSON(t *testing.T) {
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore())
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
 	defer server.Close()
 
@@ -528,7 +613,7 @@ func TestPostPublicRooms_WithFilter(t *testing.T) {
 		{ID: "!cheese:dragonite.com", Nome: "Cheese Lovers", IsPublic: true, MemberCount: 10},
 		{ID: "!code:dragonite.com", Nome: "Coding Talk", IsPublic: true, MemberCount: 5},
 	}
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
 	defer server.Close()
 
@@ -561,7 +646,7 @@ func TestPostPublicRooms_EmptyBody(t *testing.T) {
 	canais := []model.Canal{
 		{ID: "!r1:dragonite.com", Nome: "Room 1", IsPublic: true, MemberCount: 5},
 	}
-	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...))
+	h := NewTestHandler(newMockUserStore(), newMockCanalStore(canais...), nil, nil)
 	server := httptest.NewServer(http.HandlerFunc(h.postPublicRooms))
 	defer server.Close()
 
@@ -583,4 +668,350 @@ func TestPostPublicRooms_EmptyBody(t *testing.T) {
 	if len(body.Chunk) != 1 {
 		t.Fatalf("expected 1 room, got %d", len(body.Chunk))
 	}
+}
+
+// --- Testes GET makeJoin ---
+
+func TestMakeJoin_RoomNotFound(t *testing.T) {
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(), nil, nil)
+    server := newMuxServer("GET /_matrix/federation/v1/make_join/{roomId}/{userId}", h.makeJoin)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/_matrix/federation/v1/make_join/" +
+        url.PathEscape("!naoexiste:dragonite.com") + "/" +
+        url.PathEscape("@bob:remote.com"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusNotFound {
+        t.Errorf("expected 404, got %d", resp.StatusCode)
+    }
+}
+
+func TestMakeJoin_IncompatibleVersion(t *testing.T) {
+    canal := model.Canal{
+        ID: "!room:dragonite.com", IsPublic: true, JoinRules: "public", Versao: "11",
+    }
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), nil, nil)
+    server := newMuxServer("GET /_matrix/federation/v1/make_join/{roomId}/{userId}", h.makeJoin)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/_matrix/federation/v1/make_join/" +
+        url.PathEscape(canal.ID) + "/" +
+        url.PathEscape("@bob:remote.com") + "?ver=1&ver=2") // não inclui "11"
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestMakeJoin_RoomNotPublic(t *testing.T) {
+    canal := model.Canal{
+        ID: "!room:dragonite.com", IsPublic: false, JoinRules: "invite", Versao: "11",
+    }
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), nil, nil)
+    server := newMuxServer("GET /_matrix/federation/v1/make_join/{roomId}/{userId}", h.makeJoin)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/_matrix/federation/v1/make_join/" +
+        url.PathEscape(canal.ID) + "/" +
+        url.PathEscape("@bob:remote.com") + "?ver=11")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusForbidden {
+        t.Errorf("expected 403, got %d", resp.StatusCode)
+    }
+}
+
+func TestMakeJoin_HappyPath(t *testing.T) {
+    userID := "@bob:remote.com"
+    canal := model.Canal{
+        ID: "!room:dragonite.com", IsPublic: true, JoinRules: "public", Versao: "11",
+    }
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), nil, nil)
+    server := newMuxServer("GET /_matrix/federation/v1/make_join/{roomId}/{userId}", h.makeJoin)
+    defer server.Close()
+
+    resp, err := http.Get(server.URL + "/_matrix/federation/v1/make_join/" +
+        url.PathEscape(canal.ID) + "/" +
+        url.PathEscape(userID) + "?ver=11")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("expected 200, got %d", resp.StatusCode)
+    }
+
+    var body MakeJoinResponse
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        t.Fatal(err)
+    }
+    if body.RoomVersion != canal.Versao {
+        t.Errorf("expected room_version %q, got %q", canal.Versao, body.RoomVersion)
+    }
+    if body.Event.Type != "m.room.member" {
+        t.Errorf("expected type m.room.member, got %q", body.Event.Type)
+    }
+    if body.Event.Sender != userID {
+        t.Errorf("expected sender %q, got %q", userID, body.Event.Sender)
+    }
+    if body.Event.StateKey != userID {
+        t.Errorf("expected state_key %q, got %q", userID, body.Event.StateKey)
+    }
+    if body.Event.Content.Membership != "join" {
+        t.Errorf("expected membership join, got %q", body.Event.Content.Membership)
+    }
+    if body.Event.RoomID != canal.ID {
+        t.Errorf("expected room_id %q, got %q", canal.ID, body.Event.RoomID)
+    }
+}
+
+// --- Testes PUT makeJoin ---
+
+func TestSendJoin_RoomNotFound(t *testing.T) {
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(), &mockEventoStore{}, &mockUsuarioCanalStore{})
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    body, _ := json.Marshal(SendJoinRequest{
+        Type: "m.room.member", Sender: "@bob:remote.com", StateKey: "@bob:remote.com",
+        Origin: "remote.com", Content: MembershipContent{Membership: "join"},
+        RoomID: "!naoexiste:dragonite.com",
+    })
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape("!naoexiste:dragonite.com")+"/"+url.PathEscape("$event:remote.com"),
+        bytes.NewBuffer(body))
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusNotFound {
+        t.Errorf("expected 404, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_BadJSON(t *testing.T) {
+    canal := model.Canal{ID: "!room:dragonite.com", IsPublic: true}
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), &mockEventoStore{}, &mockUsuarioCanalStore{})
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$event:remote.com"),
+        bytes.NewBufferString("{invalid}"))
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_InvalidEventType(t *testing.T) {
+    canal := model.Canal{ID: "!room:dragonite.com", IsPublic: true}
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), &mockEventoStore{}, &mockUsuarioCanalStore{})
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    body, _ := json.Marshal(SendJoinRequest{
+        Type: "m.room.message", Sender: "@bob:remote.com", StateKey: "@bob:remote.com",
+        Origin: "remote.com", Content: MembershipContent{Membership: "join"},
+    })
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$e:remote.com"),
+        bytes.NewBuffer(body))
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_SenderNotEqualStateKey(t *testing.T) {
+    canal := model.Canal{ID: "!room:dragonite.com", IsPublic: true}
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), &mockEventoStore{}, &mockUsuarioCanalStore{})
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    body, _ := json.Marshal(SendJoinRequest{
+        Type: "m.room.member", Sender: "@bob:remote.com", StateKey: "@alice:remote.com",
+        Origin: "remote.com", Content: MembershipContent{Membership: "join"},
+    })
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$e:remote.com"),
+        bytes.NewBuffer(body))
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_SenderNotFromOrigin(t *testing.T) {
+    canal := model.Canal{ID: "!room:dragonite.com", IsPublic: true}
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), &mockEventoStore{}, &mockUsuarioCanalStore{})
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    // sender pertence a outro.com mas origin é remote.com
+    body, _ := json.Marshal(SendJoinRequest{
+        Type: "m.room.member", Sender: "@bob:outro.com", StateKey: "@bob:outro.com",
+        Origin: "remote.com", Content: MembershipContent{Membership: "join"},
+    })
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$e:remote.com"),
+        bytes.NewBuffer(body))
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_InvalidSignature(t *testing.T) {
+    canal := model.Canal{ID: "!room:dragonite.com", IsPublic: true}
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), &mockEventoStore{}, &mockUsuarioCanalStore{})
+
+    // keyFetcher retorna uma chave diferente da usada para assinar
+    wrongPub, _, _ := ed25519.GenerateKey(nil)
+    h.keyFetcher = func(_ string) (string, ed25519.PublicKey, error) {
+        return "ed25519:remote", wrongPub, nil
+    }
+
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    _, realPriv, _ := ed25519.GenerateKey(nil)
+    joinReq := signJoinRequest(t, realPriv, "ed25519:remote", SendJoinRequest{
+        Type: "m.room.member", Sender: "@bob:remote.com", StateKey: "@bob:remote.com",
+        Origin: "remote.com", RoomID: canal.ID, EventID: "$e:remote.com",
+        OriginServerTS: time.Now().UnixMilli(),
+        Content:        MembershipContent{Membership: "join"},
+    })
+    body, _ := json.Marshal(joinReq)
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$e:remote.com"),
+        bytes.NewBuffer(body))
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusBadRequest {
+        t.Errorf("expected 400, got %d", resp.StatusCode)
+    }
+}
+
+func TestSendJoin_HappyPath(t *testing.T) {
+    remotePub, remotePriv, _ := ed25519.GenerateKey(nil)
+    remoteKeyID := "ed25519:remote"
+    remoteOrigin := "remote.com"
+
+    canal := model.Canal{
+        ID: "!room:dragonite.com", IsPublic: true, JoinRules: "public", Versao: "11",
+    }
+    eventoStore := &mockEventoStore{}
+    ucStore := &mockUsuarioCanalStore{members: []string{"@existing:dragonite.com"}}
+
+    h := NewTestHandler(newMockUserStore(), newMockCanalStore(canal), eventoStore, ucStore)
+    h.keyFetcher = func(_ string) (string, ed25519.PublicKey, error) {
+        return remoteKeyID, remotePub, nil
+    }
+
+    server := newMuxServer("PUT /_matrix/federation/v2/send_join/{roomId}/{eventId}", h.sendJoin)
+    defer server.Close()
+
+    joinReq := signJoinRequest(t, remotePriv, remoteKeyID, SendJoinRequest{
+        Type:           "m.room.member",
+        Sender:         "@bob:" + remoteOrigin,
+        StateKey:       "@bob:" + remoteOrigin,
+        Origin:         remoteOrigin,
+        RoomID:         canal.ID,
+        EventID:        "$join-event:" + remoteOrigin,
+        OriginServerTS: time.Now().UnixMilli(),
+        Content:        MembershipContent{Membership: "join"},
+    })
+    body, _ := json.Marshal(joinReq)
+
+    req, _ := http.NewRequest(http.MethodPut,
+        server.URL+"/_matrix/federation/v2/send_join/"+
+            url.PathEscape(canal.ID)+"/"+url.PathEscape("$join-event:"+remoteOrigin),
+        bytes.NewBuffer(body))
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        bodyBytes, _ := io.ReadAll(resp.Body)
+        t.Fatalf("expected 200, got %d: %s", resp.StatusCode, bodyBytes)
+    }
+
+    var respBody SendJoinResponse
+    if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+        t.Fatal(err)
+    }
+    // state e auth_chain devem estar presentes (mesmo que vazios)
+    if respBody.State == nil {
+        t.Error("expected state to be non-nil")
+    }
+    if respBody.AuthChain == nil {
+        t.Error("expected auth_chain to be non-nil")
+    }
+    // servers_in_room deve incluir o servidor do membro existente
+    foundDragonite := false
+    for _, s := range respBody.ServersInRoom {
+        if s == "dragonite.com" {
+            foundDragonite = true
+        }
+    }
+    if !foundDragonite {
+        t.Errorf("expected dragonite.com in servers_in_room, got %v", respBody.ServersInRoom)
+    }
 }

--- a/internal/services/federation/schemas.go
+++ b/internal/services/federation/schemas.go
@@ -19,3 +19,36 @@ type VerifyKey struct {
 	Key       string `json:"key"`
 	ExpiredTS int64  `json:"expired_ts,omitzero"`
 }
+
+type PublishedRoomsChunk struct {
+    AvatarURL        string `json:"avatar_url,omitempty"`
+    CanonicalAlias   string `json:"canonical_alias,omitempty"`
+    GuestCanJoin     bool   `json:"guest_can_join"`
+    JoinRule         string `json:"join_rule,omitempty"`
+    Name             string `json:"name,omitempty"`
+    NumJoinedMembers int    `json:"num_joined_members"`
+    RoomID           string `json:"room_id"`
+    RoomType         string `json:"room_type,omitempty"`
+    Topic            string `json:"topic,omitempty"`
+    WorldReadable    bool   `json:"world_readable"`
+}
+
+type PublicRoomsResponse struct {
+    Chunk                  []PublishedRoomsChunk `json:"chunk"`
+    NextBatch              string                `json:"next_batch,omitempty"`
+    PrevBatch              string                `json:"prev_batch,omitempty"`
+    TotalRoomCountEstimate *int                  `json:"total_room_count_estimate,omitempty"`
+}
+
+type PublicRoomsFilter struct {
+    GenericSearchTerm string    `json:"generic_search_term,omitempty"`
+    RoomTypes         []*string `json:"room_types,omitempty"`
+}
+
+type PublicRoomsRequest struct {
+    Filter               *PublicRoomsFilter `json:"filter,omitempty"`
+    IncludeAllNetworks   bool               `json:"include_all_networks,omitempty"`
+    Limit                int                `json:"limit,omitempty"`
+    Since                string             `json:"since,omitempty"`
+    ThirdPartyInstanceID string             `json:"third_party_instance_id,omitempty"`
+}

--- a/internal/services/federation/schemas.go
+++ b/internal/services/federation/schemas.go
@@ -1,5 +1,9 @@
 package federation
 
+import (
+	"encoding/json"
+)
+
 type VersionResponse struct {
 	Server struct {
 		Name    string `json:"name"`
@@ -51,4 +55,60 @@ type PublicRoomsRequest struct {
     Limit                int                `json:"limit,omitempty"`
     Since                string             `json:"since,omitempty"`
     ThirdPartyInstanceID string             `json:"third_party_instance_id,omitempty"`
+}
+
+// - make_join --
+
+type MembershipContent struct {
+    JoinAuthorisedViaUsersServer string `json:"join_authorised_via_users_server,omitempty"`
+    Membership                   string `json:"membership"`
+}
+
+// EventTemplate é o template de evento unsigned retornado pelo make_join.
+type EventTemplate struct {
+    Content        MembershipContent `json:"content"`
+    Origin         string            `json:"origin"`
+    OriginServerTS int64             `json:"origin_server_ts"`
+    RoomID         string            `json:"room_id"`
+    Sender         string            `json:"sender"`
+    StateKey       string            `json:"state_key"`
+    Type           string            `json:"type"`
+}
+
+type MakeJoinResponse struct {
+    Event       EventTemplate `json:"event"`
+    RoomVersion string        `json:"room_version"`
+}
+
+// -- send_join --
+
+// SendJoinRequest é o PDU assinado enviado pelo servidor remoto
+type SendJoinRequest struct {
+    Content        MembershipContent            `json:"content"`
+    Origin         string                       `json:"origin"`
+    OriginServerTS int64                        `json:"origin_server_ts"`
+    Sender         string                       `json:"sender"`
+    StateKey       string                       `json:"state_key"`
+    Type           string                       `json:"type"`
+    RoomID         string                       `json:"room_id"`
+    EventID        string                       `json:"event_id"`
+    Signatures     map[string]map[string]string `json:"signatures"`
+}
+
+// StatePDU representa um evento de estado no formato Matrix para a resposta do send_join
+type StatePDU struct {
+    EventID        string            `json:"event_id"`
+    Type           string            `json:"type"`
+    RoomID         string            `json:"room_id"`
+    Sender         string            `json:"sender"`
+    StateKey       string            `json:"state_key"`
+    OriginServerTS int64             `json:"origin_server_ts"`
+    Content        json.RawMessage   `json:"content"`
+}
+
+type SendJoinResponse struct {
+    AuthChain      []StatePDU `json:"auth_chain"`
+    State          []StatePDU `json:"state"`
+    MembersOmitted bool       `json:"members_omitted,omitempty"`
+    ServersInRoom  []string   `json:"servers_in_room,omitempty"`
 }

--- a/internal/util/crypto.go
+++ b/internal/util/crypto.go
@@ -4,6 +4,9 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
+	"net/http"
+	"encoding/base64"
+    "encoding/json"
 
 	"github.com/caio-bernardo/dragonite/internal/types"
 )
@@ -18,4 +21,38 @@ func GenerateServerKey(serverName string, version string) (types.ServerKeyPair, 
 		PubKey:  pubKey,
 		PrivKey: privKey,
 	}, nil
+}
+
+// FetchRemoteServerKey busca a chave pública de um servidor Matrix remoto
+// Faz GET https://<serverName>/_matrix/key/v2/server e retorna a primeira chave ed25519 encontrada em verify_keys.
+func FetchRemoteServerKey(serverName string) (string, ed25519.PublicKey, error) {
+    url := fmt.Sprintf("https://%s/_matrix/key/v2/server", serverName)
+    resp, err := http.Get(url)
+    if err != nil {
+        return "", nil, fmt.Errorf("failed to fetch key from %s: %w", serverName, err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        return "", nil, fmt.Errorf("unexpected status %d fetching key from %s", resp.StatusCode, serverName)
+    }
+
+    var body struct {
+        VerifyKeys map[string]struct {
+            Key string `json:"key"`
+        } `json:"verify_keys"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        return "", nil, fmt.Errorf("failed to decode key response from %s: %w", serverName, err)
+    }
+
+    for keyID, vk := range body.VerifyKeys {
+        keyBytes, err := base64.RawStdEncoding.DecodeString(vk.Key)
+        if err != nil {
+            continue
+        }
+        return keyID, ed25519.PublicKey(keyBytes), nil
+    }
+
+    return "", nil, fmt.Errorf("no valid ed25519 key found for server %s", serverName)
 }


### PR DESCRIPTION
# Resumo das alterações - PR
## feat(federation): adiciona rota GET /_matrix/federation/v1/query/profile

- Implementado endpoint de consulta de perfil de usuário para outros servidores Matrix, conforme a [spec Server-Server API](https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1queryprofile).
- O handler valida que o user_id pertence ao servidor local antes de consultar o banco, retornando 404 M_NOT_FOUND para usuários de outros servidores
- Suporte ao parâmetro opcional field (displayname ou avatar_url), retornando apenas o campo solicitado quando presente
- Corrigido bug em GetNameAndPhotoByID no usuario_store.go: o Scan recebia 3 variáveis para uma query que retornava 2 colunas.
- Adicionados 7 testes unitários cobrindo: user_id ausente, usuário não-local, field inválido, usuário não encontrado, perfil completo e filtro por campo individual.
- Refatorado TestGetKeyServer para validar a assinatura criptograficamente em vez de comparar strings, eliminando falha intermitente por diferença de timestamp em milissegundos.

## feat(federation): adiciona rotas GET/POST /_matrix/federation/v1/publicRooms

- Implementados os dois endpoints de diretório público de salas para federation, conforme a [Server-Server API spec](https://spec.matrix.org/v1.18/server-server-api/#get_matrixfederationv1publicrooms).
- GET recebe parâmetros via query string; POST via JSON body e ambos compartilham a mesma lógica de busca em writePublicRooms.
- ListPublic no canal_store foi estendido com suporte a SearchTerm, RoomTypes, contagem total e prevBatch, recebendo um ListPublicParams no lugar de argumentos individuais
- A conversão de Canal para PublishedRoomsChunk é feita em canalToChunk, derivando guest_can_join de GuestAccess == "can_join" e world_readable de HistoryVisibility == "world_readable".
- federation.Handler passa a receber repository.ChannelStore como dependência adicional
- Adicionados schemas PublishedRoomsChunk, PublicRoomsResponse, PublicRoomsFilter e PublicRoomsRequest em federation/schemas.go
- Adicionados 6 testes de unidade nas rotas: lista vazia, lista com salas, paginação via GET, body inválido no POST, filtro por generic_search_term e body vazio no POST
- Adicionados 3 testes de integração no canal_store: paginação, busca por SearchTerm e asserção de total e tokens prev_batch/next_batch.
- Adicionados 8 testes de integração no usuario_store cobrindo os métodos sem cobertura: Search, GetNameAndPhotoByID, UpdateProfileKey, ClearProfileKey e casos de erro 404 em GetByID, GetByLocal, Update e Delete.
- Corrigido getPublicRooms em internal/services/client/rooms/routes.go: chamada de ListPublic atualizada para usar ListPublicParams; total passou a usar o valor real retornado pelo store; WorldReadable corrigido de false hardcoded para derivar de HistoryVisibility == "world_readable".
- Corrigido MockChannelStore.ListPublic em internal/services/client/rooms/routes_test.go: assinatura atualizada para (ctx, ListPublicParams) → ([]Canal, string, string, int, error) e adicionados os campos listPublicNextBatch, listPublicTotal à struct; import de repository adicionado.

## feat(federation): adicionar rotas make_join e send_join para join federado

- Implementados os dois endpoints do fluxo de joining federado conforme a [Server-Server API spec](https://spec.matrix.org/v1.18/server-server-api/#joining-rooms)
- GET /_matrix/federation/v1/make_join/{roomId}/{userId} retorna um template de evento unsigned para o servidor remoto assinar; valida existência da sala, compatibilidade de versão via parâmetro ver e join_rule = "public" antes de retornar o template
- PUT /_matrix/federation/v2/send_join/{roomId}/{eventId} recebe o evento assinado, valida tipo, membership, coerência entre sender e state_key, domínio do sender, e a assinatura ed25519 do servidor de origem; persiste o evento de membro, atualiza usuario_canal, estado_atual_canal e member_count, e retorna o estado atual da sala com auth_chain e servers_in_room
- Adicionado GetCurrentStateEvents à interface EventoStore e implementado via JOIN entre estado_atual_canal e evento
- Adicionado FetchRemoteServerKey em util/crypto.go para buscar a chave ed25519 pública de um servidor remoto via GET /_matrix/key/v2/server
keyFetcherFn injetável no Handler permite substituir a busca de chave remota nos testes sem fazer chamadas HTTP reais
- federation.Handler passa a receber EventoStore e UsuarioCanalStore como dependências adicionais
- Adicionados schemas MembershipContent, EventTemplate, MakeJoinResponse, SendJoinRequest, StatePDU e SendJoinResponse em federation/schemas.go
- Adicionados 10 testes de unidade: 4 para makeJoin (sala inexistente, versão incompatível, sala privada, happy path) e 6 para sendJoin (sala inexistente, body inválido, tipo errado, sender ≠ state_key, sender de servidor diferente, assinatura inválida, happy path com chave injetada)
- Adicionado TestEventoStore_GetCurrentStateEvents no pacote repository cobrindo sala com 3 eventos de estado e sala desconhecida

(OBS: pouca coisa né '-', quero 101 dias de folga)